### PR TITLE
filtering team list when category is selected

### DIFF
--- a/angular-app/src/app/restricted-area/marcador-form/marcador-form.component.html
+++ b/angular-app/src/app/restricted-area/marcador-form/marcador-form.component.html
@@ -16,7 +16,7 @@
                         </div>
                         <div class="row">
                             <div class="filterPadding">
-                                <select class="col-12" id="category" formControlName="cat" (change)="applyFilters()" required>
+                                <select class="col-12" id="category" formControlName="cat" (change)="applyCategoryFilter()" required>
                                     <option value={{null}}></option>
                                     <option value="aprendiz">Aprendiz</option>
                                     <option value="elite">Elite</option>
@@ -58,7 +58,7 @@
                             <div class="filterPadding">
                                 <select class="col-12" id="teams" formControlName="equipo" (change)="applyFilters()" require>
                                     <option value={{null}}></option>
-                                    <option *ngFor="let equipo of equipos" value="{{equipo.name}}">{{equipo.name}}</option>
+                                    <option *ngFor="let equipo of filteredTeams" value="{{equipo.name}}">{{equipo.name}}</option>
                                 </select>
                             </div>
                         </div>

--- a/angular-app/src/app/restricted-area/match-editor/match-editor.component.html
+++ b/angular-app/src/app/restricted-area/match-editor/match-editor.component.html
@@ -16,7 +16,7 @@
                         </div>
                         <div class="row">
                             <div class="filterPadding">
-                                <select class="col-12" id="category" formControlName="cat" (change)="applyFilters()" required>
+                                <select class="col-12" id="category" formControlName="cat" (change)="applyCategoryFilter()" required>
                                     <option value={{null}}></option>
                                     <option value="aprendiz">Aprendiz</option>
                                     <option value="elite">Elite</option>
@@ -58,7 +58,7 @@
                             <div class="filterPadding">
                                 <select class="col-12" id="teams" formControlName="equipo" (change)="applyFilters()" require>
                                     <option value={{null}}></option>
-                                    <option *ngFor="let equipo of equipos" value="{{equipo.name}}">{{equipo.name}}</option>
+                                    <option *ngFor="let equipo of filteredTeams" value="{{equipo.name}}">{{equipo.name}}</option>
                                 </select>
                             </div>
                         </div>
@@ -108,14 +108,14 @@
                     <div class="col col-4">
                         <select class="col-12" id="homeTeam" formControlName="homeTeam" require>
                             <option value={{null}}></option>
-                            <option *ngFor="let equipo of filteredequipos" value="{{equipo.id}}">{{equipo.name}}</option>
+                            <option *ngFor="let equipo of filteredTeams" value="{{equipo.id}}">{{equipo.name}}</option>
                         </select>
                     </div>
                     <div class="col col-2"> X </div>
                     <div class="col col-4">
                         <select class="col-12" id="visitorTeam" formControlName="visitorTeam" require>
                             <option value={{null}}></option>
-                            <option *ngFor="let equipo of filteredequipos" value="{{equipo.id}}">{{equipo.name}}</option>
+                            <option *ngFor="let equipo of filteredTeams" value="{{equipo.id}}">{{equipo.name}}</option>
                         </select>
                     </div>
                     <div class="col col-1"></div>

--- a/angular-app/src/app/utils/utils.ts
+++ b/angular-app/src/app/utils/utils.ts
@@ -1,6 +1,22 @@
 import {v4 as uuid} from 'uuid';
+import { Match } from '../interfaces/match';
 
 export function generateId(): string {
     return uuid()
 }
- 
+
+export function filterMatches(
+    matches: Match[], 
+     day: string | null = null,
+     gym: string | null = null, 
+     team: string | null = null,
+    ): Match[] {
+    let filteredMatches: Match[] = matches
+    if(!matches) return filteredMatches;
+    if(day) filteredMatches = filteredMatches.filter(match => match.day == day);
+    if(gym) filteredMatches = filteredMatches.filter(match => match.location.id == gym);
+    if(team) filteredMatches = filteredMatches.filter(match => 
+      match.homeTeam.name == team || match.visitorTeam.name == team
+    );
+    return filteredMatches;
+}


### PR DESCRIPTION
A team can only exist in one category (teams with same name in different categories are different resources). Hence, removing teams not in the category to avoid repeated names and team selection from a different category. Picking a team not in the category results on no matches degrading CX