### PR TITLE
Add payment receipt upload with three-state approval workflow

### DIFF
--- a/angular-app/src/app/Builders/team-builder.ts
+++ b/angular-app/src/app/Builders/team-builder.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CY_KEY, DynamoDb, IndexId, PK_KEY, SK_KEY, SPK_KEY, SSK_KEY } from "src/app/aws-clients/dynamodb";
-import { Team, TeamKey } from "../interfaces/team";
+import { PaymentStatus, Team, TeamKey } from "../interfaces/team";
 import { AttributeValue } from "@aws-sdk/client-dynamodb";
 import {v4 as uuidv4} from 'uuid';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
@@ -146,7 +146,23 @@ export class TeamBuilder {
         await ddb.deleteItem(record);
     }
 
-    private buildTeam(item: Record<string, AttributeValue>): Team {        
+    async updatePaymentStatus(ddb: DynamoDb, teamId: string, status: PaymentStatus) {
+        let key = {
+            [PK_KEY]: {S: `${TeamKey.PREFIX}.${teamId}`},
+            [SK_KEY]: {S: `${TeamKey.SK}`}
+        };
+        let updateExpression = 'SET #payattr = :val';
+        let expressionAttributeNames: Record<string, string> = {
+            '#payattr': `${TeamKey.PAYMENT_STATUS}`,
+        };
+        let expressionAttributeValues: Record<string, AttributeValue> = {
+            ':val': {S: status},
+        };
+
+        await ddb.updateItem(key, updateExpression, expressionAttributeNames, expressionAttributeValues);
+    }
+
+    private buildTeam(item: Record<string, AttributeValue>): Team {
         return {
             id: item[PK_KEY].S!.split('.')[1],
             name: item[TeamKey.NAME].S!,
@@ -156,6 +172,7 @@ export class TeamBuilder {
             coachName: item[TeamKey.COACH_NAME]?.S,
             location: item[TeamKey.LOACTION]?.S,
             year: item[TeamKey.YEAR].S ? item[TeamKey.YEAR].S : "",
+            paymentStatus: (item[TeamKey.PAYMENT_STATUS]?.S as PaymentStatus) ?? PaymentStatus.PENDING,
         }
     }
 

--- a/angular-app/src/app/interfaces/team.ts
+++ b/angular-app/src/app/interfaces/team.ts
@@ -12,6 +12,12 @@ export function getCategories(): string[] {
     ]
 }
 
+export enum PaymentStatus {
+    PENDING = 'pendiente',
+    IN_REVIEW = 'en_revision',
+    APPROVED = 'aprovado',
+}
+
 export enum TeamKey {
     ID = 'id',
     NAME = 'name',
@@ -22,6 +28,7 @@ export enum TeamKey {
     PREFIX = 'team',
     SK = 'team.data',
     CATEGORY = 'category',
+    PAYMENT_STATUS = 'paymentStatus',
 }
 
 export interface Team {
@@ -33,6 +40,7 @@ export interface Team {
     category?: string
     location: string | undefined
     year?: string
+    paymentStatus?: PaymentStatus
 }
 
 export interface MatchTeam {

--- a/angular-app/src/app/restricted-area/list-teams/list-teams.component.html
+++ b/angular-app/src/app/restricted-area/list-teams/list-teams.component.html
@@ -11,16 +11,23 @@
       <div style="min-width: 1000px;">
     <table class="row">
         <tr class="row">
-            <th [ngClass]="{'col': true, 'col-3': userrole != 'coach', 'col-5': userrole === 'coach'}"> <a [routerLink]="" (click)="sortTeamsByName()">Equipo</a></th>
+            <th [ngClass]="{'col': true, 'col-3': userrole != 'coach', 'col-4': userrole === 'coach'}"> <a [routerLink]="" (click)="sortTeamsByName()">Equipo</a></th>
             <th class="col col-2"> <a [routerLink]="" (click)="sortTeamsByCategory()">Categoria</a></th>
-            <th [ngClass]="{'col': true, 'col-3': userrole != 'coach', 'col-5': userrole === 'coach'}"> <a [routerLink]="" (click)="sortTeamsByLocation()">Localidad</a></th>
-            <th *ngIf="userrole != 'coach'" class="col col-4 groupLast"> <a [routerLink]="" (click)="sortTeamsByCoach()">Coach</a></th>
+            <th [ngClass]="{'col': true, 'col-3': userrole != 'coach', 'col-4': userrole === 'coach'}"> <a [routerLink]="" (click)="sortTeamsByLocation()">Localidad</a></th>
+            <th *ngIf="userrole != 'coach'" class="col col-2"> <a [routerLink]="" (click)="sortTeamsByCoach()">Coach</a></th>
+            <th class="col col-2 groupLast">Pago</th>
         </tr>
         <tr class="row" *ngFor="let team of teams" [routerLink]="" (click)="viewTeam(team.id)">
-            <td [ngClass]="{'col': true, 'col-3': userrole != 'coach', 'col-5': userrole === 'coach'}"><u>{{team.name}}</u></td>
+            <td [ngClass]="{'col': true, 'col-3': userrole != 'coach', 'col-4': userrole === 'coach'}"><u>{{team.name}}</u></td>
             <td class="col col-2">{{team.category}}</td>
-            <td [ngClass]="{'col': true, 'col-3': userrole != 'coach', 'col-5': userrole === 'coach'}">{{team.location}}</td>
-            <td *ngIf="userrole != 'coach'" class="col col-4">{{coaches.get(team.coachId)?.name}}</td>
+            <td [ngClass]="{'col': true, 'col-3': userrole != 'coach', 'col-4': userrole === 'coach'}">{{team.location}}</td>
+            <td *ngIf="userrole != 'coach'" class="col col-2">{{coaches.get(team.coachId)?.name}}</td>
+            <td class="col col-2"
+                [style.color]="team.paymentStatus === 'aprovado' ? 'green' : team.paymentStatus === 'en_revision' ? 'goldenrod' : 'red'"
+                [style.cursor]="isAdmin ? 'pointer' : 'default'"
+                (click)="isAdmin && openPaymentReview(team, $event)">
+                <span [style.text-decoration]="isAdmin ? 'underline' : 'none'">{{team.paymentStatus === 'aprovado' ? 'Aprovado' : team.paymentStatus === 'en_revision' ? 'En Revisión' : 'Pendiente'}}</span>
+            </td>
         </tr>
     </table>
       </div>
@@ -94,8 +101,49 @@
   
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-danger" 
+        <button type="button" class="btn btn-danger"
                 (click)="closeErrorPopup()">
+          Cerrar
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!--Payment review modal-->
+<div class="modal"
+      tabindex="-1"
+      role="dialog"
+      [ngStyle]="{'display':displayPaymentReview}">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header dark-header">
+        <h5 class="modal-title">Comprobante de Pago - {{reviewTeam?.name}}</h5>
+        <button type="button" class="btn-close" (click)="closePaymentReview()" aria-label="Close">
+        </button>
+      </div>
+      <div class="modal-body">
+        <div *ngIf="loadingReviewReceipt" class="text-center">
+          <div class="spinner-border text-dark" role="status">
+            <span class="sr-only">Loading...</span>
+          </div>
+        </div>
+
+        <div *ngIf="!loadingReviewReceipt && reviewReceiptUrl">
+          <img [src]="reviewReceiptUrl" alt="Comprobante de Pago" style="max-width: 100%; max-height: 400px;">
+        </div>
+
+        <div *ngIf="!loadingReviewReceipt && !reviewReceiptUrl">
+          <p>No se ha subido comprobante de pago.</p>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button *ngIf="reviewReceiptUrl && reviewTeam?.paymentStatus !== 'aprovado'" type="button" class="btn btn-success"
+          (click)="approvePayment()">
+          Aprobar
+        </button>
+        <button type="button" class="btn btn-secondary"
+          (click)="closePaymentReview()">
           Cerrar
         </button>
       </div>

--- a/angular-app/src/app/restricted-area/list-teams/list-teams.component.ts
+++ b/angular-app/src/app/restricted-area/list-teams/list-teams.component.ts
@@ -1,8 +1,9 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { AuthService } from '../../auth.service';
 import { DynamoDb } from '../../aws-clients/dynamodb';
+import { S3 } from '../../aws-clients/s3';
 import { TeamBuilder } from '../../Builders/team-builder';
-import { Team } from '../../interfaces/team';
+import { Team, PaymentStatus } from '../../interfaces/team';
 import { Coach } from '../../interfaces/coach';
 import { UserBuilder } from '../../Builders/user-builder';
 import { TOURNAMENT_YEAR } from '../../aws-clients/constants';
@@ -47,6 +48,7 @@ export class ListTeamsComponent {
     featureFlags: FeatureFlag | undefined = undefined
   
     @Input() ddb!: DynamoDb;
+    @Input() s3!: S3;
     loading = true;
     teams: Team[] = [];
     pastTeams: Team[] = [];
@@ -175,6 +177,40 @@ export class ListTeamsComponent {
       // TODO: implement
       console.log("Remove team "+teamId);
     }
+    displayPaymentReview = "none";
+    reviewTeam: Team | undefined;
+    reviewReceiptUrl: string | null = null;
+    loadingReviewReceipt = false;
+
+    openPaymentReview(team: Team, event: Event){
+      event.stopPropagation();
+      this.reviewTeam = team;
+      this.reviewReceiptUrl = null;
+      this.loadingReviewReceipt = true;
+      this.displayPaymentReview = "block";
+
+      const fileName = `payment-receipt-${team.name}-${team.id}`;
+      this.s3.downloadFile(fileName).then((data) => {
+        if (data) {
+          const blob = new Blob([data as any]);
+          this.reviewReceiptUrl = URL.createObjectURL(blob);
+        }
+        this.loadingReviewReceipt = false;
+      });
+    }
+
+    closePaymentReview(){
+      this.displayPaymentReview = "none";
+    }
+
+    async approvePayment(){
+      if (this.reviewTeam) {
+        await this.teamBuilder.updatePaymentStatus(this.ddb, this.reviewTeam.id, PaymentStatus.APPROVED);
+        this.reviewTeam.paymentStatus = PaymentStatus.APPROVED;
+        this.closePaymentReview();
+      }
+    }
+
     displayStyle = "none";
     openPopup() {
       this.displayStyle = "block";

--- a/angular-app/src/app/restricted-area/restricted-area.component.html
+++ b/angular-app/src/app/restricted-area/restricted-area.component.html
@@ -75,7 +75,7 @@
                         </div>
                         
                         <div *ngIf="listTeamsView">
-                            <app-list-teams [ddb]="ddb" (callViewTeam)="showViewTeams($event)" (callAddTeam)="showAddTeam()"></app-list-teams>
+                            <app-list-teams [ddb]="ddb" [s3]="s3" (callViewTeam)="showViewTeams($event)" (callAddTeam)="showAddTeam()"></app-list-teams>
                         </div>
                         
                         <div [hidden]="!viewTeamsView">

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.html
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.html
@@ -16,6 +16,9 @@
         <i class="fa fa-trash"></i>
       </button>
     </h2>
+    <p *ngIf="paymentStatus === 'aprovado'" style="color: green;" class="text-center">Comprobante de pago aprovado</p>
+    <p *ngIf="paymentStatus === 'en_revision'" style="color: goldenrod;" class="text-center">Comprobante de pago en revisión</p>
+    <p *ngIf="paymentStatus === 'pendiente'" style="color: red;" class="text-center">Comprobante de pago pendiente</p>
 
     <table class="row">
         <tr class="row" *ngIf="userrole!='coach'">
@@ -32,7 +35,8 @@
         </tr>
     </table>
     <p></p>
-    <button *ngIf="editable" type="button" (click)="selectCaptan()" class="btn btn-dark"> Seleccionar Capitán</button>
+    <button *ngIf="editable" type="button" (click)="selectCaptan()" class="btn btn-dark"> Seleccionar Capitán</button>&nbsp;
+    <button *ngIf="editable" type="button" (click)="openPaymentReceipt()" class="btn btn-dark"> Subir Comprobante de Pago</button>
     <p></p>
     <div class="scroll-container">
       <div style="min-width: 400px;">
@@ -250,6 +254,56 @@
         <button type="button" class="btn btn-danger" 
                 (click)="confirmDeletePlayer()">
           Confirmar
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!--Payment receipt modal-->
+<div class="modal"
+      tabindex="-1"
+      role="dialog"
+      [ngStyle]="{'display':displayPaymentReceipt}">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header dark-header">
+        <h5 class="modal-title">Comprobante de Pago</h5>
+        <button type="button" class="btn-close" (click)="closePaymentReceipt()" aria-label="Close">
+        </button>
+      </div>
+      <div class="modal-body">
+        <div *ngIf="loadingReceipt" class="text-center">
+          <div class="spinner-border text-dark" role="status">
+            <span class="sr-only">Loading...</span>
+          </div>
+        </div>
+
+        <div *ngIf="!loadingReceipt && existingReceiptUrl && !receiptPreview">
+          <p><strong>Comprobante actual:</strong></p>
+          <img [src]="existingReceiptUrl" alt="Comprobante de Pago" style="max-width: 100%; max-height: 300px;">
+        </div>
+
+        <div *ngIf="!loadingReceipt && !existingReceiptUrl && !receiptPreview">
+          <p>No se ha subido comprobante de pago.</p>
+        </div>
+
+        <hr *ngIf="!loadingReceipt">
+
+        <div *ngIf="!loadingReceipt" class="frow">
+          <label for="receipt-file">{{existingReceiptUrl ? 'Actualizar archivo:' : 'Seleccionar archivo:'}}&nbsp;</label>
+          <input type="file" id="receipt-file" accept="image/*" (change)="onReceiptFileSelected($event)">
+        </div>
+        <p *ngIf="receiptError" style="color: red;">{{receiptError}}</p>
+        <div *ngIf="receiptPreview" class="mt-3">
+          <img [src]="receiptPreview" alt="Preview" style="max-width: 100%; max-height: 300px;">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-danger"
+          [disabled]="!receiptFile"
+          (click)="uploadPaymentReceipt()">
+          Subir
         </button>
       </div>
     </div>

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
@@ -1,8 +1,9 @@
+import { Buffer } from 'buffer';
 import { Component, EventEmitter, Input, Output, QueryList, ViewChild, ViewChildren } from '@angular/core';
 import { AuthService } from '../../auth.service';
 import { DynamoDb } from '../../aws-clients/dynamodb';
 import { TeamBuilder } from '../../Builders/team-builder';
-import { Team, getCategories, TeamKey } from '../../interfaces/team';
+import { Team, getCategories, TeamKey, PaymentStatus } from '../../interfaces/team';
 import { Player, PlayerKey } from '../../interfaces/player';
 import { PlayerBuilder } from '../../Builders/player-builder';
 import { formatDate } from "@angular/common";
@@ -31,6 +32,7 @@ export class ViewTeamsComponent {
   displayCaptan = "none";
   displayEditTeam = "none";
   displayAddExistingPlayer = "none";
+  displayPaymentReceipt = "none";
   addExistingPlayerForm: FormGroup;
 
   constructor(private fb: FormBuilder,
@@ -69,6 +71,15 @@ export class ViewTeamsComponent {
   newplayerid = uuidv4();
   featureFlags: FeatureFlag | undefined = undefined
   selectedCaptain:string = "";
+
+  receiptFile: Buffer | undefined;
+  receiptContentType: string = "";
+  receiptPreview: string | null = null;
+  receiptIsImage: boolean = false;
+  receiptFileName: string = "";
+  existingReceiptUrl: string | null = null;
+  loadingReceipt: boolean = false;
+  paymentStatus: PaymentStatus = PaymentStatus.PENDING;
 
   editable = true;
 
@@ -122,7 +133,12 @@ export class ViewTeamsComponent {
     this.players = await this.playerBuilder.getPlayersByTeam(this.ddb, teamId);
     this.players = this.players.filter((p: Player) => p.year! === this.team!.year!);
     await this.getAllPlayers();
+    this.checkPaymentStatus();
     this.loading = false;
+  }
+
+  private checkPaymentStatus(){
+    this.paymentStatus = this.team?.paymentStatus ?? PaymentStatus.PENDING;
   }
 
   @Output() callListTeam = new EventEmitter<string>();
@@ -172,6 +188,68 @@ export class ViewTeamsComponent {
 
   closeCaptan(){
     this.displayCaptan = "none";
+  }
+
+  async openPaymentReceipt(){
+    this.receiptFile = undefined;
+    this.receiptContentType = "";
+    this.receiptPreview = null;
+    this.receiptIsImage = false;
+    this.receiptFileName = "";
+    this.existingReceiptUrl = null;
+    this.loadingReceipt = true;
+    this.displayPaymentReceipt = "block";
+
+    if (this.team) {
+      const fileName = `payment-receipt-${this.team.name}-${this.team.id}`;
+      const data = await this.s3.downloadFile(fileName);
+      if (data) {
+        const blob = new Blob([data as any]);
+        this.existingReceiptUrl = URL.createObjectURL(blob);
+      }
+    }
+    this.loadingReceipt = false;
+  }
+
+  closePaymentReceipt(){
+    this.displayPaymentReceipt = "none";
+  }
+
+  receiptError: string = "";
+
+  onReceiptFileSelected(event: any): void {
+    const file: File = event.target.files[0];
+    if (file) {
+      if (!file.type.startsWith('image/')) {
+        this.receiptError = "El archivo debe ser una imagen.";
+        this.receiptFile = undefined;
+        this.receiptPreview = null;
+        return;
+      }
+
+      this.receiptError = "";
+      this.receiptFileName = file.name;
+      this.receiptContentType = file.type;
+      this.receiptIsImage = true;
+
+      const reader = new FileReader();
+      reader.readAsArrayBuffer(file);
+      reader.onload = () => {
+        this.receiptFile = Buffer.from(reader.result as ArrayBuffer);
+        this.receiptPreview = URL.createObjectURL(file);
+      };
+    }
+  }
+
+  async uploadPaymentReceipt(){
+    if (this.receiptFile && this.team) {
+      const fileName = `payment-receipt-${this.team.name}-${this.team.id}`;
+      await this.s3.uploadFile(fileName, this.receiptFile, this.receiptContentType);
+      await this.teamBuilder.updatePaymentStatus(this.ddb, this.team.id, PaymentStatus.IN_REVIEW);
+      console.log("Payment receipt uploaded for team:", this.team.name);
+      this.paymentStatus = PaymentStatus.IN_REVIEW;
+      this.closePaymentReceipt();
+    }
   }
 
   openEditTeam(){


### PR DESCRIPTION
Coaches can upload a "Comprobante de Pago" from the team view page. The receipt is stored in S3 and a paymentStatus field is persisted in DynamoDB with three states: pendiente (red), en_revision (yellow), and aprovado (green). The list-teams view shows the status column and allows admins to click it to review and approve the payment receipt.