### PR TITLE
Require payment receipt on team creation and centralize upload logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ dist
 .tern-port
 
 .idea
+.claude

--- a/angular-app/src/app/Builders/team-builder.ts
+++ b/angular-app/src/app/Builders/team-builder.ts
@@ -6,6 +6,7 @@ import {v4 as uuidv4} from 'uuid';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { TOURNAMENT_YEAR } from '../aws-clients/constants';
 import { CoachKey } from '../interfaces/coach';
+import { S3 } from '../aws-clients/s3';
 
 @Injectable({
     providedIn: 'root'
@@ -144,6 +145,16 @@ export class TeamBuilder {
         record[SK_KEY] = {S: `${TeamKey.SK}`};
 
         await ddb.deleteItem(record);
+    }
+
+    static getReceiptFileName(teamName: string, teamId: string): string {
+        return `payment-receipt-${teamName}-${teamId}`;
+    }
+
+    async uploadPaymentReceipt(ddb: DynamoDb, s3: S3, team: Team, file: Buffer | Uint8Array, contentType: string): Promise<void> {
+        const fileName = TeamBuilder.getReceiptFileName(team.name, team.id);
+        await s3.uploadFile(fileName, file, contentType);
+        await this.updatePaymentStatus(ddb, team.id, PaymentStatus.IN_REVIEW);
     }
 
     async updatePaymentStatus(ddb: DynamoDb, teamId: string, status: PaymentStatus) {

--- a/angular-app/src/app/restricted-area/add-team/add-team.component.html
+++ b/angular-app/src/app/restricted-area/add-team/add-team.component.html
@@ -47,12 +47,20 @@
                         <div class="frow">
                             <input type="text" id="location" formControlName="location" class="form-control">
                         </div>
+                        <label class="frow" for="receipt-file">Comprobante de Pago:&nbsp;<span style="color: red;">*</span></label>
+                        <div class="frow">
+                            <input type="file" id="receipt-file" accept="image/*" (change)="onReceiptFileSelected($event)">
+                        </div>
+                        <p *ngIf="receiptError" style="color: red;">{{receiptError}}</p>
+                        <div *ngIf="receiptPreview" class="mt-2">
+                            <img [src]="receiptPreview" alt="Preview" style="max-width: 100%; max-height: 200px;">
+                        </div>
                     </div>
                   </div>
                 </div>
             </div>
         <div class="frow">
-          <button type="submit"  class="btn btn-danger">Guardar</button>
+          <button type="submit" class="btn btn-danger" [disabled]="!teamForm.valid || (!receiptFile && userrole !== 'admin')">Guardar</button>
         </div>
     </form>
     </div>

--- a/angular-app/src/app/restricted-area/add-team/add-team.component.ts
+++ b/angular-app/src/app/restricted-area/add-team/add-team.component.ts
@@ -1,9 +1,11 @@
+import { Buffer } from 'buffer';
 import { Component, EventEmitter, Input, Output, QueryList, ViewChildren } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { AuthService } from '../../auth.service';
 import { Team, getCategories } from '../../interfaces/team';
 import { Player } from '../../interfaces/player';
 import { DynamoDb } from '../../aws-clients/dynamodb';
+import { S3 } from '../../aws-clients/s3';
 import { TeamBuilder } from '../../Builders/team-builder';
 import { PlayerBuilder } from '../../Builders/player-builder';
 import {v4 as uuidv4} from 'uuid';
@@ -32,6 +34,7 @@ export class AddTeamComponent {
   }
 
   @Input() ddb!: DynamoDb;
+  @Input() s3!: S3;
 
   userId = this.authService.getUserId();
   userName = this.authService.getUserName();
@@ -61,6 +64,31 @@ export class AddTeamComponent {
   editable = true;
 
   saved: boolean = false;
+
+  receiptFile: Buffer | undefined;
+  receiptContentType: string = "";
+  receiptPreview: string | null = null;
+  receiptError: string = "";
+
+  onReceiptFileSelected(event: any): void {
+    const file: File = event.target.files[0];
+    if (file) {
+      if (!file.type.startsWith('image/')) {
+        this.receiptError = "El archivo debe ser una imagen.";
+        this.receiptFile = undefined;
+        this.receiptPreview = null;
+        return;
+      }
+      this.receiptError = "";
+      this.receiptContentType = file.type;
+      const reader = new FileReader();
+      reader.readAsArrayBuffer(file);
+      reader.onload = () => {
+        this.receiptFile = Buffer.from(reader.result as ArrayBuffer);
+        this.receiptPreview = URL.createObjectURL(file);
+      };
+    }
+  }
 
   async ngOnInit() {
     if(this.userrole != "coach"){
@@ -97,6 +125,11 @@ export class AddTeamComponent {
   }
 
   async onSubmit() {
+    if (!this.receiptFile && this.userrole !== 'admin') {
+      this.receiptError = "El comprobante de pago es requerido.";
+      return;
+    }
+
     let selectedCoachId = this.userId;
     let selectedCoachName = this.userName;
     if(this.userrole != "coach"){
@@ -113,6 +146,7 @@ export class AddTeamComponent {
     if (!await this.validateTeam()){
       this.popUpMsg = "Este equipo ya existe!";
       this.openPopup();
+      return;
     }
 
     let newTeam : Team = {id: this.selectedTeamId,
@@ -125,6 +159,9 @@ export class AddTeamComponent {
     }
 
     await this.teamBuilder.createTeam(this.ddb, newTeam);
+    if (this.receiptFile) {
+      await this.teamBuilder.uploadPaymentReceipt(this.ddb, this.s3, newTeam, this.receiptFile, this.receiptContentType);
+    }
 
     this.saved = true;
     this.popUpMsg = "Equipo guardado!";

--- a/angular-app/src/app/restricted-area/list-teams/list-teams.component.ts
+++ b/angular-app/src/app/restricted-area/list-teams/list-teams.component.ts
@@ -189,7 +189,7 @@ export class ListTeamsComponent {
       this.loadingReviewReceipt = true;
       this.displayPaymentReview = "block";
 
-      const fileName = `payment-receipt-${team.name}-${team.id}`;
+      const fileName = TeamBuilder.getReceiptFileName(team.name, team.id);
       this.s3.downloadFile(fileName).then((data) => {
         if (data) {
           const blob = new Blob([data as any]);

--- a/angular-app/src/app/restricted-area/restricted-area.component.html
+++ b/angular-app/src/app/restricted-area/restricted-area.component.html
@@ -51,7 +51,7 @@
                         </div>
                         
                         <div *ngIf="addTeamView">
-                            <app-add-team [ddb]="ddb" (callViewTeam)="showViewTeams($event)" (callListTeam)="showListTeams()"></app-add-team>
+                            <app-add-team [ddb]="ddb" [s3]="s3" (callViewTeam)="showViewTeams($event)" (callListTeam)="showListTeams()"></app-add-team>
                         </div>
                         
                         <div *ngIf="addGymView">

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
@@ -201,7 +201,7 @@ export class ViewTeamsComponent {
     this.displayPaymentReceipt = "block";
 
     if (this.team) {
-      const fileName = `payment-receipt-${this.team.name}-${this.team.id}`;
+      const fileName = TeamBuilder.getReceiptFileName(this.team.name, this.team.id);
       const data = await this.s3.downloadFile(fileName);
       if (data) {
         const blob = new Blob([data as any]);
@@ -243,10 +243,7 @@ export class ViewTeamsComponent {
 
   async uploadPaymentReceipt(){
     if (this.receiptFile && this.team) {
-      const fileName = `payment-receipt-${this.team.name}-${this.team.id}`;
-      await this.s3.uploadFile(fileName, this.receiptFile, this.receiptContentType);
-      await this.teamBuilder.updatePaymentStatus(this.ddb, this.team.id, PaymentStatus.IN_REVIEW);
-      console.log("Payment receipt uploaded for team:", this.team.name);
+      await this.teamBuilder.uploadPaymentReceipt(this.ddb, this.s3, this.team, this.receiptFile, this.receiptContentType);
       this.paymentStatus = PaymentStatus.IN_REVIEW;
       this.closePaymentReceipt();
     }


### PR DESCRIPTION
Moved receipt upload logic into TeamBuilder (uploadPaymentReceipt and getReceiptFileName) so it can be reused across components. Added payment receipt file input to the add-team form as a required field for non-admin users. Admins can create teams without a receipt.