### PR TITLE
Fix scout role incorrectly setting isAdmin/isCoach flags & Fix add-player flow: set player ID for new players and fix save order

### DIFF
--- a/angular-app/src/app/restricted-area/list-players/list-players.component.ts
+++ b/angular-app/src/app/restricted-area/list-players/list-players.component.ts
@@ -53,7 +53,7 @@ export class ListPlayersComponent {
         this.isCoach = true;
       }
       if(this.userrole == "scout"){
-        this.isAdmin = true;
+        this.isScout = true;
       }
       if(this.userrole == "coach"){
         this.isCoach = true;

--- a/angular-app/src/app/restricted-area/list-teams/list-teams.component.ts
+++ b/angular-app/src/app/restricted-area/list-teams/list-teams.component.ts
@@ -77,7 +77,7 @@ export class ListTeamsComponent {
         this.isCoach = true;
       }
       if(this.userrole == "scout"){
-        this.isAdmin = true;
+        this.isScout = true;
       }
       if(this.userrole == "coach"){
         this.isCoach = true;

--- a/angular-app/src/app/restricted-area/view-teams/add-player/add-player.component.ts
+++ b/angular-app/src/app/restricted-area/view-teams/add-player/add-player.component.ts
@@ -62,12 +62,15 @@ export class AddPlayerComponent {
 
 
   async loadPlayer(playerId: string){
-    this.player = this.playerBuilder.getEmptyPlayer()
-    
     let existingPlayer = this.teamplayers.find(p => p.id === playerId)
     if (existingPlayer){
       this.player = existingPlayer;
       console.log("found:", existingPlayer.name);
+      let bday = new Date(this.player.birthday)
+      this.playerForm.controls.bday.setValue(this.datepipe.transform(bday, 'yyyy-MM-dd')!)
+    } else {
+      this.player = this.playerBuilder.getEmptyPlayer()
+      this.player.id = playerId;
     }
 
     this.playerForm.controls.nombre.setValue(this.player.name)
@@ -75,8 +78,6 @@ export class AddPlayerComponent {
     this.playerForm.controls.categoria.setValue(this.player.category)
     this.playerForm.controls.altura.setValue(this.player.height)
     this.playerForm.controls.peso.setValue(this.player.weight)
-    let bday = new Date(this.player.birthday)
-    this.playerForm.controls.bday.setValue(this.datepipe.transform(bday, 'yyyy-MM-dd')!)
     this.playerForm.controls.posicion.setValue(this.player.position)
 
     if (this.player.imageType){
@@ -144,20 +145,17 @@ export class AddPlayerComponent {
     this.player.birthday = this.datepipe.transform(bday, 'yyyy-MM-dd')!;
   }
 
-  async savePlayer(){
+  async savePlayerPhoto(){
+    console.log(`Saving player photo: ${this.player.name} - ${this.player.id}`);
     if(this.player.imageType && this.imgToUpload){
       await this.s3.uploadFile(
         this.player.id,
         this.imgToUpload!,
         this.player.imageType!,
       );
-      console.log("File uploaded")
+      console.log("Player photo uploaded")
       this.imgToUpload = undefined
     }
-
-    this.getPlayerInput();
-    console.log("Saving player: "+this.player.name);
-    console.log(this.player);
   }
 }
 

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
@@ -116,15 +116,17 @@ export class ViewTeamsComponent {
   }
 
   async ngOnInit() {
-    if(this.userrole != "coach"){
+    this.reloadLoginStatus();
+
+    if(this.userrole == "admin") {
       this.coaches = await this.userBuilder.getCoaches(this.ddb);
-    }
-    else{
+    } else if(this.userrole == "coach"){
       this.featureFlags = await this.featureFlagBuilder.getFeatureFlags(this.ddb);
       this.editable = this.featureFlags ? this.featureFlags.editTeams : false;
     }
-    
-    this.reloadLoginStatus();
+    else {
+      console.warn("User role not allowed to view teams: ", this.userrole)
+    }
   }
   
   async loadTeam(teamId: string){
@@ -289,8 +291,7 @@ export class ViewTeamsComponent {
     console.log("View player "+playerId);
     this.selectedPlayer = (this.players.filter((p)=>p.id === playerId))[0];
     this.newplayerid = this.selectedPlayer.id;
-    await this.viewChild.loadPlayer(this.newplayerid);
-    this.addPlayer();
+    this.addPlayer()
   }
 
   deletePlayer(){
@@ -358,7 +359,7 @@ export class ViewTeamsComponent {
   }
 
   async addPlayer(){
-    await this.viewChild.loadPlayer(this.newplayerid);
+    await this.addPlayerViewChild.loadPlayer(this.newplayerid);
     this.displayAddPlayer = "block"
   }
   closeAddPlayerPopup() {
@@ -366,22 +367,16 @@ export class ViewTeamsComponent {
     this.newplayerid = uuidv4();
   }
 
-  @ViewChild(AddPlayerComponent) viewChild!: AddPlayerComponent;
-  async getInputPlayer(){
-    let newPlayer: Player = this.playerBuilder.getEmptyPlayer();
-    await this.viewChild.savePlayer()
-    console.log("updated player:");
-    console.log(this.viewChild.player);
-    newPlayer = this.viewChild.player;
-    return newPlayer;
-  }
-
+  @ViewChild(AddPlayerComponent) addPlayerViewChild!: AddPlayerComponent;
   async confirmAddPlayer() {
-    let newPlayer = await this.getInputPlayer()
-    await this.playerBuilder.createPlayer(this.ddb, newPlayer)
-    console.log("Saved "+newPlayer.name);
+    // loads the player values from AddPlayerComponent
+    this.addPlayerViewChild.getPlayerInput();
+    let newPlayer = this.addPlayerViewChild.player;
+    console.log("Adding Player:", newPlayer);
+    await this.playerBuilder.createPlayer(this.ddb, newPlayer);
+    await this.addPlayerViewChild.savePlayerPhoto();
+    console.log(`Saved Player: ${newPlayer.name} - ${newPlayer.id}`);
     await this.loadTeam(this.team!.id);
-    this.newplayerid = uuidv4();
-    this.displayAddPlayer = "none";
+    this.closeAddPlayerPopup();
   }
 }

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
@@ -108,7 +108,7 @@ export class ViewTeamsComponent {
       this.isCoach = true;
     }
     if(this.userrole == "scout"){
-      this.isAdmin = true;
+      this.isScout = true;
     }
     if(this.userrole == "coach"){
       this.isCoach = true;

--- a/angular-app/src/app/scouts/scouts.component.ts
+++ b/angular-app/src/app/scouts/scouts.component.ts
@@ -82,7 +82,6 @@ export class ScoutsComponent {
       }
       if(this.userrole == "scout"){
         this.isScout = true;
-        this.isCoach = true;
       }
       if(this.userrole == "coach"){
         this.isCoach = true;


### PR DESCRIPTION
Fix scout role incorrectly setting isAdmin/isCoach flags
Scouts were being granted admin or coach privileges in several
components due to copy-paste errors in reloadLoginStatus. Now
scouts only set isScout = true.

---

Fix add-player flow: set player ID for new players and fix save order

- Set player.id from input when creating new players so the photo
  upload button is visible immediately
- Renamed savePlayer to savePlayerPhoto to clarify its responsibility
- Call getPlayerInput before createPlayer to ensure form values are
  used instead of stale empty player object
- Moved bday form setValue into the existing-player branch only
- Renamed viewChild to addPlayerViewChild for clarity
- Removed duplicate loadPlayer call in editPlayer