### PR TITLE
Support multiple payment receipt files with append-only approved uploads

### DIFF
--- a/angular-app/src/app/Builders/team-builder.ts
+++ b/angular-app/src/app/Builders/team-builder.ts
@@ -147,13 +147,19 @@ export class TeamBuilder {
         await ddb.deleteItem(record);
     }
 
-    static getReceiptFileName(teamName: string, teamId: string): string {
-        return `payment-receipt-${teamName}-${teamId}`;
+    static getReceiptFileName(teamName: string, teamId: string, index: number): string {
+        return `payment-receipt-${teamName}-${teamId}-${index}`;
     }
 
-    async uploadPaymentReceipt(ddb: DynamoDb, s3: S3, team: Team, file: Buffer | Uint8Array, contentType: string): Promise<void> {
-        const fileName = TeamBuilder.getReceiptFileName(team.name, team.id);
-        await s3.uploadFile(fileName, file, contentType);
+    static getReceiptFilePrefix(teamName: string, teamId: string): string {
+        return `payment-receipt-${teamName}-${teamId}-`;
+    }
+
+    async uploadPaymentReceipts(ddb: DynamoDb, s3: S3, team: Team, files: {data: Buffer | Uint8Array, contentType: string}[], startIndex: number = 0): Promise<void> {
+        for (let i = 0; i < files.length; i++) {
+            const fileName = TeamBuilder.getReceiptFileName(team.name, team.id, startIndex + i);
+            await s3.uploadFile(fileName, files[i].data, files[i].contentType);
+        }
         await this.updatePaymentStatus(ddb, team.id, PaymentStatus.IN_REVIEW);
     }
 

--- a/angular-app/src/app/restricted-area/add-team/add-team.component.html
+++ b/angular-app/src/app/restricted-area/add-team/add-team.component.html
@@ -49,18 +49,21 @@
                         </div>
                         <label class="frow" for="receipt-file">Comprobante de Pago:&nbsp;<span style="color: red;">*</span></label>
                         <div class="frow">
-                            <input type="file" id="receipt-file" accept="image/*" (change)="onReceiptFileSelected($event)">
+                            <input type="file" id="receipt-file" accept="image/*" multiple (change)="onReceiptFilesSelected($event)">
                         </div>
                         <p *ngIf="receiptError" style="color: red;">{{receiptError}}</p>
-                        <div *ngIf="receiptPreview" class="mt-2">
-                            <img [src]="receiptPreview" alt="Preview" style="max-width: 100%; max-height: 200px;">
+                        <div *ngIf="receiptFiles.length > 0" class="mt-2">
+                            <div *ngFor="let rf of receiptFiles; let i = index" style="display: inline-block; position: relative; margin-right: 8px; margin-bottom: 8px;">
+                                <img [src]="rf.preview" alt="Preview" style="max-height: 150px;">
+                                <button type="button" class="btn btn-sm btn-outline-danger" style="position: absolute; top: 0; right: 0;" (click)="removeReceiptFile(i)">✗</button>
+                            </div>
                         </div>
                     </div>
                   </div>
                 </div>
             </div>
         <div class="frow">
-          <button type="submit" class="btn btn-danger" [disabled]="!teamForm.valid || (!receiptFile && userrole !== 'admin')">Guardar</button>
+          <button type="submit" class="btn btn-danger" [disabled]="!teamForm.valid || (receiptFiles.length === 0 && userrole !== 'admin')">Guardar</button>
         </div>
     </form>
     </div>

--- a/angular-app/src/app/restricted-area/add-team/add-team.component.ts
+++ b/angular-app/src/app/restricted-area/add-team/add-team.component.ts
@@ -65,29 +65,37 @@ export class AddTeamComponent {
 
   saved: boolean = false;
 
-  receiptFile: Buffer | undefined;
-  receiptContentType: string = "";
-  receiptPreview: string | null = null;
+  receiptFiles: {data: Buffer, contentType: string, preview: string}[] = [];
   receiptError: string = "";
 
-  onReceiptFileSelected(event: any): void {
-    const file: File = event.target.files[0];
-    if (file) {
-      if (!file.type.startsWith('image/')) {
-        this.receiptError = "El archivo debe ser una imagen.";
-        this.receiptFile = undefined;
-        this.receiptPreview = null;
+  onReceiptFilesSelected(event: any): void {
+    const files: FileList = event.target.files;
+    if (!files || files.length === 0) return;
+
+    for (let i = 0; i < files.length; i++) {
+      if (!files[i].type.startsWith('image/')) {
+        this.receiptError = "Todos los archivos deben ser imágenes.";
         return;
       }
-      this.receiptError = "";
-      this.receiptContentType = file.type;
+    }
+
+    this.receiptError = "";
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
       const reader = new FileReader();
       reader.readAsArrayBuffer(file);
       reader.onload = () => {
-        this.receiptFile = Buffer.from(reader.result as ArrayBuffer);
-        this.receiptPreview = URL.createObjectURL(file);
+        this.receiptFiles.push({
+          data: Buffer.from(reader.result as ArrayBuffer),
+          contentType: file.type,
+          preview: URL.createObjectURL(file)
+        });
       };
     }
+  }
+
+  removeReceiptFile(index: number): void {
+    this.receiptFiles.splice(index, 1);
   }
 
   async ngOnInit() {
@@ -127,7 +135,7 @@ export class AddTeamComponent {
   }
 
   async onSubmit() {
-    if (!this.receiptFile && this.userrole !== 'admin') {
+    if (this.receiptFiles.length === 0 && this.userrole !== 'admin') {
       this.receiptError = "El comprobante de pago es requerido.";
       return;
     }
@@ -161,8 +169,8 @@ export class AddTeamComponent {
     }
 
     await this.teamBuilder.createTeam(this.ddb, newTeam);
-    if (this.receiptFile) {
-      await this.teamBuilder.uploadPaymentReceipt(this.ddb, this.s3, newTeam, this.receiptFile, this.receiptContentType);
+    if (this.receiptFiles.length > 0) {
+      await this.teamBuilder.uploadPaymentReceipts(this.ddb, this.s3, newTeam, this.receiptFiles);
     }
 
     this.saved = true;

--- a/angular-app/src/app/restricted-area/list-teams/list-teams.component.html
+++ b/angular-app/src/app/restricted-area/list-teams/list-teams.component.html
@@ -129,16 +129,18 @@
           </div>
         </div>
 
-        <div *ngIf="!loadingReviewReceipt && reviewReceiptUrl">
-          <img [src]="reviewReceiptUrl" alt="Comprobante de Pago" style="max-width: 100%; max-height: 400px;">
+        <div *ngIf="!loadingReviewReceipt && reviewReceiptUrls.length > 0">
+          <div *ngFor="let url of reviewReceiptUrls" class="mb-2">
+            <img [src]="url" alt="Comprobante de Pago" style="max-width: 100%; max-height: 300px;">
+          </div>
         </div>
 
-        <div *ngIf="!loadingReviewReceipt && !reviewReceiptUrl">
+        <div *ngIf="!loadingReviewReceipt && reviewReceiptUrls.length === 0">
           <p>No se ha subido comprobante de pago.</p>
         </div>
       </div>
       <div class="modal-footer">
-        <button *ngIf="reviewReceiptUrl && reviewTeam?.paymentStatus !== 'aprovado'" type="button" class="btn btn-success"
+        <button *ngIf="reviewReceiptUrls.length > 0 && reviewTeam?.paymentStatus !== 'aprovado'" type="button" class="btn btn-success"
           (click)="approvePayment()">
           Aprobar
         </button>

--- a/angular-app/src/app/restricted-area/list-teams/list-teams.component.ts
+++ b/angular-app/src/app/restricted-area/list-teams/list-teams.component.ts
@@ -179,24 +179,27 @@ export class ListTeamsComponent {
     }
     displayPaymentReview = "none";
     reviewTeam: Team | undefined;
-    reviewReceiptUrl: string | null = null;
+    reviewReceiptUrls: string[] = [];
     loadingReviewReceipt = false;
 
-    openPaymentReview(team: Team, event: Event){
+    async openPaymentReview(team: Team, event: Event){
       event.stopPropagation();
       this.reviewTeam = team;
-      this.reviewReceiptUrl = null;
+      this.reviewReceiptUrls = [];
       this.loadingReviewReceipt = true;
       this.displayPaymentReview = "block";
 
-      const fileName = TeamBuilder.getReceiptFileName(team.name, team.id);
-      this.s3.downloadFile(fileName).then((data) => {
+      for (let i = 0; i < 10; i++) {
+        const fileName = TeamBuilder.getReceiptFileName(team.name, team.id, i);
+        const data = await this.s3.downloadFile(fileName);
         if (data) {
           const blob = new Blob([data as any]);
-          this.reviewReceiptUrl = URL.createObjectURL(blob);
+          this.reviewReceiptUrls.push(URL.createObjectURL(blob));
+        } else {
+          break;
         }
-        this.loadingReviewReceipt = false;
-      });
+      }
+      this.loadingReviewReceipt = false;
     }
 
     closePaymentReview(){

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.html
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.html
@@ -36,7 +36,7 @@
     </table>
     <p></p>
     <button *ngIf="editable" type="button" (click)="selectCaptan()" class="btn btn-dark"> Seleccionar Capitán</button>&nbsp;
-    <button *ngIf="editable && paymentStatus !== 'aprovado'" type="button" (click)="openPaymentReceipt()" class="btn btn-dark"> Subir Comprobante de Pago</button>
+    <button *ngIf="editable" type="button" (click)="openPaymentReceipt()" class="btn btn-dark"> Subir Comprobante de Pago</button>
     <p></p>
     <div class="scroll-container">
       <div style="min-width: 400px;">
@@ -279,29 +279,34 @@
           </div>
         </div>
 
-        <div *ngIf="!loadingReceipt && existingReceiptUrl && !receiptPreview">
-          <p><strong>Comprobante actual:</strong></p>
-          <img [src]="existingReceiptUrl" alt="Comprobante de Pago" style="max-width: 100%; max-height: 300px;">
+        <div *ngIf="!loadingReceipt && existingReceiptUrls.length > 0">
+          <p><strong>Comprobantes actuales{{paymentStatus === 'aprovado' ? ' (aprovados)' : ''}}:</strong></p>
+          <div *ngFor="let url of existingReceiptUrls" class="mb-2">
+            <img [src]="url" alt="Comprobante de Pago" style="max-width: 100%; max-height: 200px;">
+          </div>
         </div>
 
-        <div *ngIf="!loadingReceipt && !existingReceiptUrl && !receiptPreview">
+        <div *ngIf="!loadingReceipt && existingReceiptUrls.length === 0 && receiptFiles.length === 0">
           <p>No se ha subido comprobante de pago.</p>
         </div>
 
         <hr *ngIf="!loadingReceipt">
 
         <div *ngIf="!loadingReceipt" class="frow">
-          <label for="receipt-file">{{existingReceiptUrl ? 'Actualizar archivo:' : 'Seleccionar archivo:'}}&nbsp;</label>
-          <input type="file" id="receipt-file" accept="image/*" (change)="onReceiptFileSelected($event)">
+          <label for="receipt-file">Agregar archivos:&nbsp;</label>
+          <input type="file" id="receipt-file" accept="image/*" multiple (change)="onReceiptFilesSelected($event)">
         </div>
         <p *ngIf="receiptError" style="color: red;">{{receiptError}}</p>
-        <div *ngIf="receiptPreview" class="mt-3">
-          <img [src]="receiptPreview" alt="Preview" style="max-width: 100%; max-height: 300px;">
+        <div *ngIf="receiptFiles.length > 0" class="mt-3">
+          <div *ngFor="let rf of receiptFiles; let i = index" class="mb-2" style="position: relative; display: inline-block; margin-right: 8px;">
+            <img [src]="rf.preview" alt="Preview" style="max-height: 150px;">
+            <button type="button" class="btn btn-sm btn-outline-danger" style="position: absolute; top: 0; right: 0;" (click)="removeReceiptFile(i)">✗</button>
+          </div>
         </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-danger"
-          [disabled]="!receiptFile"
+          [disabled]="receiptFiles.length === 0"
           (click)="uploadPaymentReceipt()">
           Subir
         </button>

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
@@ -72,12 +72,8 @@ export class ViewTeamsComponent {
   featureFlags: FeatureFlag | undefined = undefined
   selectedCaptain:string = "";
 
-  receiptFile: Buffer | undefined;
-  receiptContentType: string = "";
-  receiptPreview: string | null = null;
-  receiptIsImage: boolean = false;
-  receiptFileName: string = "";
-  existingReceiptUrl: string | null = null;
+  receiptFiles: {data: Buffer, contentType: string, preview: string}[] = [];
+  existingReceiptUrls: string[] = [];
   loadingReceipt: boolean = false;
   paymentStatus: PaymentStatus = PaymentStatus.PENDING;
 
@@ -193,21 +189,22 @@ export class ViewTeamsComponent {
   }
 
   async openPaymentReceipt(){
-    this.receiptFile = undefined;
-    this.receiptContentType = "";
-    this.receiptPreview = null;
-    this.receiptIsImage = false;
-    this.receiptFileName = "";
-    this.existingReceiptUrl = null;
+    this.receiptFiles = [];
+    this.existingReceiptUrls = [];
+    this.receiptError = "";
     this.loadingReceipt = true;
     this.displayPaymentReceipt = "block";
 
     if (this.team) {
-      const fileName = TeamBuilder.getReceiptFileName(this.team.name, this.team.id);
-      const data = await this.s3.downloadFile(fileName);
-      if (data) {
-        const blob = new Blob([data as any]);
-        this.existingReceiptUrl = URL.createObjectURL(blob);
+      for (let i = 0; i < 10; i++) {
+        const fileName = TeamBuilder.getReceiptFileName(this.team.name, this.team.id, i);
+        const data = await this.s3.downloadFile(fileName);
+        if (data) {
+          const blob = new Blob([data as any]);
+          this.existingReceiptUrls.push(URL.createObjectURL(blob));
+        } else {
+          break;
+        }
       }
     }
     this.loadingReceipt = false;
@@ -219,33 +216,41 @@ export class ViewTeamsComponent {
 
   receiptError: string = "";
 
-  onReceiptFileSelected(event: any): void {
-    const file: File = event.target.files[0];
-    if (file) {
+  onReceiptFilesSelected(event: any): void {
+    const files: FileList = event.target.files;
+    if (!files || files.length === 0) return;
+
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
       if (!file.type.startsWith('image/')) {
-        this.receiptError = "El archivo debe ser una imagen.";
-        this.receiptFile = undefined;
-        this.receiptPreview = null;
+        this.receiptError = "Todos los archivos deben ser imágenes.";
         return;
       }
+    }
 
-      this.receiptError = "";
-      this.receiptFileName = file.name;
-      this.receiptContentType = file.type;
-      this.receiptIsImage = true;
-
+    this.receiptError = "";
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
       const reader = new FileReader();
       reader.readAsArrayBuffer(file);
       reader.onload = () => {
-        this.receiptFile = Buffer.from(reader.result as ArrayBuffer);
-        this.receiptPreview = URL.createObjectURL(file);
+        this.receiptFiles.push({
+          data: Buffer.from(reader.result as ArrayBuffer),
+          contentType: file.type,
+          preview: URL.createObjectURL(file)
+        });
       };
     }
   }
 
+  removeReceiptFile(index: number): void {
+    this.receiptFiles.splice(index, 1);
+  }
+
   async uploadPaymentReceipt(){
-    if (this.receiptFile && this.team) {
-      await this.teamBuilder.uploadPaymentReceipt(this.ddb, this.s3, this.team, this.receiptFile, this.receiptContentType);
+    if (this.receiptFiles.length > 0 && this.team) {
+      const startIndex = this.existingReceiptUrls.length;
+      await this.teamBuilder.uploadPaymentReceipts(this.ddb, this.s3, this.team, this.receiptFiles, startIndex);
       this.paymentStatus = PaymentStatus.IN_REVIEW;
       this.closePaymentReceipt();
     }


### PR DESCRIPTION
- Receipt uploads now support multiple files per team, stored with indexed S3 keys (payment-receipt-{name}-{id}-{index})
- New files append after existing ones so approved receipts are never overwritten
- Adding new files sets status back to in_review for admin re-approval
- File picker uses multiple attribute across all components
- Preview gallery with per-file remove button before upload