### PR TITLE
Allow receipt deletion only while in pending review, lock when approved

### DIFF
--- a/angular-app/src/app/Builders/team-builder.ts
+++ b/angular-app/src/app/Builders/team-builder.ts
@@ -179,6 +179,11 @@ export class TeamBuilder {
         await ddb.updateItem(key, updateExpression, expressionAttributeNames, expressionAttributeValues);
     }
 
+    async deletePaymentReceipt(s3: S3, team: Team, index: number): Promise<void> {
+        const fileName = TeamBuilder.getReceiptFileName(team.name, team.id, index);
+        await s3.deleteFile(fileName);
+    }
+
     private buildTeam(item: Record<string, AttributeValue>): Team {
         return {
             id: item[PK_KEY].S!.split('.')[1],

--- a/angular-app/src/app/aws-clients/s3.ts
+++ b/angular-app/src/app/aws-clients/s3.ts
@@ -1,4 +1,4 @@
-import { S3Client, GetObjectCommand, ListObjectsCommand, ListObjectsCommandInput, GetObjectCommandInput, PutObjectCommand, PutObjectCommandInput } from "@aws-sdk/client-s3";
+import { S3Client, GetObjectCommand, ListObjectsCommand, ListObjectsCommandInput, GetObjectCommandInput, PutObjectCommand, PutObjectCommandInput, DeleteObjectCommand, DeleteObjectCommandInput } from "@aws-sdk/client-s3";
 import { REGION, COGNITO_UNAUTHENTICATED_CREDENTIALS, TOURNAMENT_YEAR } from "./constants";
 import { AwsCredentialIdentity, Provider } from "@aws-sdk/types"
 import { Cache } from "./cache";
@@ -94,6 +94,28 @@ export class S3 {
             return true;
         } catch (err) {
             console.error('Error uploading file:', err);
+            return false;
+        }
+    }
+
+    async deleteFile(fileName: string): Promise<boolean> {
+        const objectKey = `${IMAGE_PATH}/${fileName}`;
+        console.log(`Deleting file: ${objectKey}`);
+
+        const input: DeleteObjectCommandInput = {
+            Bucket: GLADIADORES_BUCKET_NAME,
+            Key: objectKey
+        };
+
+        try {
+            await this.client.send(new DeleteObjectCommand(input));
+            console.log('Successfully deleted file:', objectKey);
+            if (this.cache.has(objectKey)) {
+                this.cache.delete(objectKey);
+            }
+            return true;
+        } catch (err) {
+            console.error('Error deleting file:', err);
             return false;
         }
     }

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.html
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.html
@@ -36,7 +36,7 @@
     </table>
     <p></p>
     <button *ngIf="editable" type="button" (click)="selectCaptan()" class="btn btn-dark"> Seleccionar Capitán</button>&nbsp;
-    <button *ngIf="editable" type="button" (click)="openPaymentReceipt()" class="btn btn-dark"> Subir Comprobante de Pago</button>
+    <button *ngIf="editable && paymentStatus !== 'aprovado'" type="button" (click)="openPaymentReceipt()" class="btn btn-dark"> Subir Comprobante de Pago</button>
     <p></p>
     <div class="scroll-container">
       <div style="min-width: 400px;">
@@ -280,9 +280,10 @@
         </div>
 
         <div *ngIf="!loadingReceipt && existingReceiptUrls.length > 0">
-          <p><strong>Comprobantes actuales{{paymentStatus === 'aprovado' ? ' (aprovados)' : ''}}:</strong></p>
-          <div *ngFor="let url of existingReceiptUrls" class="mb-2">
+          <p><strong>Comprobantes actuales:</strong></p>
+          <div *ngFor="let url of existingReceiptUrls; let i = index" class="mb-2" style="position: relative; display: inline-block; margin-right: 8px;">
             <img [src]="url" alt="Comprobante de Pago" style="max-width: 100%; max-height: 200px;">
+            <button type="button" class="btn btn-sm btn-outline-danger" style="position: absolute; top: 0; right: 0;" (click)="deleteExistingReceipt(i)">✗</button>
           </div>
         </div>
 

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
@@ -198,7 +198,7 @@ export class ViewTeamsComponent {
     if (this.team) {
       for (let i = 0; i < 10; i++) {
         const fileName = TeamBuilder.getReceiptFileName(this.team.name, this.team.id, i);
-        const data = await this.s3.downloadFile(fileName);
+        const data = await this.s3.downloadFile(fileName, false);
         if (data) {
           const blob = new Blob([data as any]);
           this.existingReceiptUrls.push(URL.createObjectURL(blob));
@@ -245,6 +245,36 @@ export class ViewTeamsComponent {
 
   removeReceiptFile(index: number): void {
     this.receiptFiles.splice(index, 1);
+  }
+
+  async deleteExistingReceipt(index: number){
+    if (!this.team) return;
+    if (!confirm('¿Estás seguro que deseas eliminar este comprobante?')) return;
+
+    const totalExisting = this.existingReceiptUrls.length;
+
+    for (let i = index; i < totalExisting - 1; i++) {
+      const nextFileName = TeamBuilder.getReceiptFileName(this.team.name, this.team.id, i + 1);
+      const data = await this.s3.downloadFile(nextFileName, false);
+      if (data) {
+        const currentFileName = TeamBuilder.getReceiptFileName(this.team.name, this.team.id, i);
+        await this.s3.uploadFile(currentFileName, data, 'image/jpeg');
+        this.s3.invalidateCache(currentFileName);
+      }
+    }
+    await this.teamBuilder.deletePaymentReceipt(this.s3, this.team, totalExisting - 1);
+
+    this.existingReceiptUrls = [];
+    for (let i = 0; i < totalExisting - 1; i++) {
+      const fileName = TeamBuilder.getReceiptFileName(this.team.name, this.team.id, i);
+      const data = await this.s3.downloadFile(fileName, false);
+      if (data) {
+        const blob = new Blob([data as any]);
+        this.existingReceiptUrls.push(URL.createObjectURL(blob));
+      } else {
+        break;
+      }
+    }
   }
 
   async uploadPaymentReceipt(){


### PR DESCRIPTION
- Hide upload button when payment status is approved
- All receipts are deletable while status is pendiente or en_revision
- Once approved, no modifications are allowed
- Added S3 deleteFile method and TeamBuilder deletePaymentReceipt
- Re-indexes remaining files after deletion to maintain sequential keys
- Reloads receipt gallery from S3 after delete to avoid stale URLs