### PR TITLE
Add player position checkboxes, number, CURP, and liability waiver

### DIFF
--- a/angular-app/src/app/Builders/player-builder.ts
+++ b/angular-app/src/app/Builders/player-builder.ts
@@ -6,6 +6,7 @@ import { AttributeValue } from "@aws-sdk/client-dynamodb";
 import { Validators } from '@angular/forms';
 import { TeamKey } from '../interfaces/team';
 import { TOURNAMENT_YEAR } from '../aws-clients/constants';
+import { S3, LIABILITY_WAIVER_PATH } from '../aws-clients/s3';
 
 @Injectable({
     providedIn: 'root'
@@ -27,6 +28,32 @@ export class PlayerBuilder {
         await ddb.updateItem(key, updateExpression, expressionAttributeNames, expressionAttributeValues);
     }
 
+    static getLiabilityWaiverFileName(playerId: string): string {
+        return `liability-waiver-${playerId}`;
+    }
+
+    async uploadLiabilityWaiver(ddb: DynamoDb, s3: S3, playerId: string, data: Buffer | Uint8Array, contentType: string): Promise<void> {
+        const fileName = PlayerBuilder.getLiabilityWaiverFileName(playerId);
+        await s3.uploadFile(fileName, data, contentType, LIABILITY_WAIVER_PATH);
+        await this.updateLiabilityWaiver(ddb, playerId, fileName);
+    }
+
+    async updateLiabilityWaiver(ddb: DynamoDb, playerId: string, fileName: string) {
+        let key = {
+            [PK_KEY]: {S: `${PlayerKey.PREFIX}.${playerId}`},
+            [SK_KEY]: {S: `${PlayerKey.PREFIX}.data`}
+        };
+        let updateExpression = 'SET #waiverattr = :val';
+        let expressionAttributeNames: Record<string, string> = {
+            '#waiverattr': `${PlayerKey.LIABILITY_WAIVER}`,
+        };
+        let expressionAttributeValues: Record<string, AttributeValue> = {
+            ':val': {S: fileName},
+        };
+
+        await ddb.updateItem(key, updateExpression, expressionAttributeNames, expressionAttributeValues);
+    }
+
     async createPlayer(ddb: DynamoDb, player: Player) {
         let playerRecord: Record<string, AttributeValue> = {}
         playerRecord[PK_KEY] = {S: `${PlayerKey.PREFIX}.${player.id}`}
@@ -38,6 +65,9 @@ export class PlayerBuilder {
         playerRecord[PlayerKey.HEIGHT] = {S: `${player.height}`};
         playerRecord[PlayerKey.WEIGHT] = {S: `${player.weight}`};
         playerRecord[PlayerKey.POSITION] = {S: `${player.position}`};
+        playerRecord[PlayerKey.NUMBER] = {S: `${player.number}`};
+        playerRecord[PlayerKey.CURP] = {S: `${player.curp}`};
+        playerRecord[PlayerKey.LIABILITY_WAIVER] = {S: `${player.liabilityWaiver ?? ""}`};
         playerRecord[PlayerKey.IMAGE_TYPE] = {S: `${player.imageType?player.imageType:""}`};
         playerRecord[CY_KEY] = {S: TOURNAMENT_YEAR};
         playerRecord[PlayerKey.BIRTHDAY] = {S: `${player.birthday}`};
@@ -105,6 +135,9 @@ export class PlayerBuilder {
             height: item[PlayerKey.HEIGHT].S ? item[PlayerKey.HEIGHT].S! : "",
             weight: item[PlayerKey.WEIGHT].S ? item[PlayerKey.WEIGHT].S! : "",
             position: item[PlayerKey.POSITION].S ? item[PlayerKey.POSITION].S! : "",
+            number: item[PlayerKey.NUMBER]?.S && item[PlayerKey.NUMBER].S !== "null" ? item[PlayerKey.NUMBER].S! : "",
+            curp: item[PlayerKey.CURP]?.S ? item[PlayerKey.CURP].S! : "",
+            liabilityWaiver: item[PlayerKey.LIABILITY_WAIVER]?.S ? item[PlayerKey.LIABILITY_WAIVER].S! : "",
             birthday: item[PlayerKey.BIRTHDAY].S ? item[PlayerKey.BIRTHDAY].S! : "",
             imageType: item[PlayerKey.IMAGE_TYPE] ? item[PlayerKey.IMAGE_TYPE].S : "",
             year: item[CY_KEY].S ? item[CY_KEY].S : ""
@@ -143,9 +176,14 @@ export class PlayerBuilder {
             height: "",
             weight: "",
             position: "",
+            number: "",
+            curp: "",
+            liabilityWaiver: "",
             birthday: ""
         }
     }
+
+    static positions = ['1', '2', '3', '4', '5']
 
     static defaultForm = {
         nombre: ['', Validators.required],
@@ -153,7 +191,8 @@ export class PlayerBuilder {
         categoria: ['', Validators.required],
         altura: [''],
         peso: [''],
-        bday: [''],
-        posicion: ['']
+        numero: [''],
+        curp: [''],
+        bday: ['']
     }
 }

--- a/angular-app/src/app/aws-clients/s3.ts
+++ b/angular-app/src/app/aws-clients/s3.ts
@@ -15,6 +15,9 @@ const MATCH_DATA_PATH = `${MATCH_DATA}/${TOURNAMENT_PREFIX}${CURRENT_TOURNAMENT}
 const REPORT_DATA = "reports"
 const REPORT_PATH = `${REPORT_DATA}/${TOURNAMENT_PREFIX}${TOURNAMENT_YEAR}`
 const IMAGE_PATH = "images"
+const LIABILITY_WAIVER_PATH = "liability-waiver"
+
+export { LIABILITY_WAIVER_PATH };
 
 
 export enum ReportType {
@@ -67,10 +70,10 @@ export class S3 {
 
     }
 
-    async uploadFile(fileName: string, fileContent: string | Uint8Array | Buffer, contentType: string): Promise<boolean> {
+    async uploadFile(fileName: string, fileContent: string | Uint8Array | Buffer, contentType: string, path: string = IMAGE_PATH): Promise<boolean> {
         console.log(`Uploading file: ${fileName}`)
-        
-        const objectKey = `${IMAGE_PATH}/${fileName}`;
+
+        const objectKey = `${path}/${fileName}`;
 
         const input: PutObjectCommandInput = {
             Bucket: GLADIADORES_BUCKET_NAME,
@@ -202,6 +205,30 @@ export class S3 {
                 return fileContent;
             }
             
+            return undefined;
+        } catch (err) {
+            console.error('Error downloading file:', err);
+            return undefined;
+        }
+    }
+
+    async downloadFileWithType(fileName: string, path: string = IMAGE_PATH): Promise<{data: Uint8Array, contentType: string} | undefined> {
+        const objectKey = `${path}/${fileName}`;
+        console.log(`Downloading file with type: ${objectKey}`)
+
+        const input: GetObjectCommandInput = {
+            Bucket: GLADIADORES_BUCKET_NAME,
+            Key: objectKey
+        };
+
+        try {
+            const response = await this.client.send(new GetObjectCommand(input));
+            const fileContent = await response.Body?.transformToByteArray();
+
+            if (fileContent) {
+                return {data: fileContent, contentType: response.ContentType ?? 'application/octet-stream'};
+            }
+
             return undefined;
         } catch (err) {
             console.error('Error downloading file:', err);

--- a/angular-app/src/app/interfaces/player.ts
+++ b/angular-app/src/app/interfaces/player.ts
@@ -8,6 +8,9 @@ export interface Player {
     height: string,
     weight: string,
     position: string,
+    number: string,
+    curp: string,
+    liabilityWaiver: string,
     birthday: string,
     year?: string
 }
@@ -24,6 +27,9 @@ export enum PlayerKey {
     HEIGHT = 'height',
     WEIGHT = 'weight',
     POSITION = 'position',
+    NUMBER = 'number',
+    CURP = 'curp',
+    LIABILITY_WAIVER = 'liabilityWaiver',
     BIRTHDAY = 'birthday',
     IMAGE_TYPE = 'image',
     PREFIX = 'player'

--- a/angular-app/src/app/participants/participants.component.html
+++ b/angular-app/src/app/participants/participants.component.html
@@ -77,12 +77,14 @@
 
         <table class="row">
             <tr class="row">
-                <th class="col col-lg-8 col-12"> <a [routerLink]="">Player</a></th>
-                <th class="col col-lg-4 col-12"> <a [routerLink]="">Position</a></th>
+                <th class="col col-lg-1 col-2"> <a [routerLink]="">#</a></th>
+                <th class="col col-lg-7 col-6"> <a [routerLink]="">Player</a></th>
+                <th class="col col-lg-4 col-4"> <a [routerLink]="">Position</a></th>
             </tr>
             <tr class="row" *ngFor="let player of players">
-                <td class="col col-lg-8 col-12">{{player.name}}{{(player.id === team?.captainId) ? " (Capitán)" : ""}}</td>
-                <td class="col col-lg-4 col-12">{{player.position}}</td>
+                <td class="col col-lg-1 col-2">{{player.number}}</td>
+                <td class="col col-lg-7 col-6">{{player.name}}{{(player.id === team?.captainId) ? " (Capitán)" : ""}}</td>
+                <td class="col col-lg-4 col-4">{{player.position}}</td>
             </tr>
         </table>
         

--- a/angular-app/src/app/restricted-area/evaluacion/evaluacion.component.html
+++ b/angular-app/src/app/restricted-area/evaluacion/evaluacion.component.html
@@ -46,6 +46,8 @@
                   </div>
                   <label class="frow" for="edad">Posicion Registrada:&nbsp;</label>
                   <input class="frow" disabled id="position" type="text" value="{{selectedPlayer.position}}">
+                  <label class="frow" for="numero">Número:&nbsp;</label>
+                  <input class="frow" disabled id="numero" type="number" value="{{selectedPlayer.number}}">
                 </div>
               </div>
             </div>

--- a/angular-app/src/app/restricted-area/evaluacion/evaluacion.component.ts
+++ b/angular-app/src/app/restricted-area/evaluacion/evaluacion.component.ts
@@ -40,7 +40,7 @@ export class EvaluacionComponent {
   teams: Team[] = [];
   teamplayers: Player[] = [];
   selectedCategoria: string = "";
-  selectedPlayer: Player = {id: '', team: '', name:'',age:"",category:'', height:'',weight:'',position:'',birthday:''};;
+  selectedPlayer: Player = {id: '', team: '', name:'',age:"",category:'', height:'',weight:'',position:'',number:'',curp:'',liabilityWaiver:'',birthday:''};;
   displayStyle = "none";
   displayPhotoPopup = "none";
   submitReportMessage = "Evaluacion guardada!"
@@ -140,7 +140,7 @@ export class EvaluacionComponent {
     )
     this.teams = this.teams.concat(teams)
     this.teamplayers = [];
-    this.selectedPlayer = {id: '', team: '', name:'',age:"",category:'', height:'',weight:'',position:'',birthday:''};
+    this.selectedPlayer = {id: '', team: '', name:'',age:"",category:'', height:'',weight:'',position:'',number:'',curp:'',liabilityWaiver:'',birthday:''};
     this.imageUrl = "assets/no-avatar.png"
   }
 
@@ -156,7 +156,7 @@ export class EvaluacionComponent {
           )
         }
     });
-    this.selectedPlayer = {id: '', team: '', name:'',age:"",category:'', height:'',weight:'',position:'',birthday:''};
+    this.selectedPlayer = {id: '', team: '', name:'',age:"",category:'', height:'',weight:'',position:'',number:'',curp:'',liabilityWaiver:'',birthday:''};
     this.imageUrl = "assets/no-avatar.png"
   }
 

--- a/angular-app/src/app/restricted-area/evaluar-partido/evaluar-partido.component.html
+++ b/angular-app/src/app/restricted-area/evaluar-partido/evaluar-partido.component.html
@@ -80,6 +80,7 @@
                         <img width="100%" [src]="player.imageUrl" class="rounded">
                         <p>{{player.name}}</p>
                         <p>Posición: {{player.position}}</p>
+                        <p>Número: {{player.number}}</p>
                     </button>
                 </div>
             </div>
@@ -121,6 +122,8 @@
                         <input class="frow" disabled id="nombre" type="text" value="{{selectedPlayer!.name}}">
                         <label class="frow" for="position">Posicion Registrada:&nbsp;</label>
                         <input class="frow" disabled id="position" type="text" value="{{selectedPlayer!.position}}">
+                        <label class="frow" for="numero">Número:&nbsp;</label>
+                        <input class="frow" disabled id="numero" type="number" value="{{selectedPlayer!.number}}">
                     </div>
                     </div>
                 </div>

--- a/angular-app/src/app/restricted-area/list-players/list-players.component.html
+++ b/angular-app/src/app/restricted-area/list-players/list-players.component.html
@@ -11,12 +11,14 @@
         <div style="min-width: 600px;">
             <table class="row">
                 <tr class="row">
-                    <th class="col col-5"> <a [routerLink]="" (click)="sortPlayersByName()">Jugador</a></th>
+                    <th class="col col-1"> <a [routerLink]="">#</a></th>
+                    <th class="col col-4"> <a [routerLink]="" (click)="sortPlayersByName()">Jugador</a></th>
                     <th class="col col-4"> <a [routerLink]="" (click)="sortPlayersByEquipo()">Equipo</a></th>
                     <th class="col col-3"> <a [routerLink]="" (click)="sortPlayersByCategory()">Categoria</a></th>
                 </tr>
                 <tr class="row" *ngFor="let player of players" [routerLink]="" (click)="showPlayer(player)" >
-                    <td class="col col-5">{{player.name}}</td>
+                    <td class="col col-1">{{player.number}}</td>
+                    <td class="col col-4">{{player.name}}</td>
                     <td class="col col-4">{{uTeams.get(player.team)}}</td>
                     <td class="col col-3">{{player.category}}</td>
                 </tr>
@@ -49,7 +51,10 @@
             
                   <label class="frow" for="position">Posición:&nbsp;</label>
                   <input class="frow" type="text" value="{{player!.position}}">
-            
+
+                  <label class="frow" for="numero">Número:&nbsp;</label>
+                  <input class="frow" type="number" value="{{player!.number}}">
+
                   <label class="frow" for="altura">Altura (cm):&nbsp;</label>
                   <input class="frow" type="number" min="1" max="300" value="{{player!.height}}">
                   <label class="frow" for="peso">Peso (kg):&nbsp;</label>

--- a/angular-app/src/app/restricted-area/view-teams/add-player/add-player.component.html
+++ b/angular-app/src/app/restricted-area/view-teams/add-player/add-player.component.html
@@ -15,12 +15,58 @@
       <input class="frow" formControlName="bday" class="form-control" type="date" value="{{player.birthday}}">
 
       <label class="frow" for="position">Posición:&nbsp;</label>
-      <input class="frow" formControlName="posicion" class="form-control" type="text" value="{{player.position}}">
+      <div class="frow">
+        <label *ngFor="let pos of positions" style="margin-right: 12px;">
+          <input type="checkbox" [checked]="selectedPositions[pos]" (change)="togglePosition(pos)">
+          &nbsp;{{pos}}
+        </label>
+      </div>
 
+      <label class="frow" for="numero">Número:&nbsp;</label>
+      <input class="frow" formControlName="numero" class="form-control" type="number" min="0" max="99" value="{{player.number}}">
+      <label class="frow" for="curp">CURP:&nbsp;</label>
+      <input class="frow" formControlName="curp" class="form-control" type="text" value="{{player.curp}}">
       <label class="frow" for="altura">Altura (cm):&nbsp;</label>
       <input class="frow" formControlName="altura" class="form-control" type="number" min="1" max="300" value="{{player.height}}">
       <label class="frow" for="peso">Peso (kg):&nbsp;</label>
       <input class="frow" formControlName="peso" class="form-control" type="number" min="1" max="300" value="{{player.weight}}">
+
+      <label class="frow" for="waiverFile">Carta Responsiva:&nbsp;</label>
+      <div class="frow">
+        <input id="waiverFile" type="file" (change)="onWaiverSelected($event)" accept="image/*,application/pdf">
+      </div>
+      <p *ngIf="waiverError" style="color: red;">{{waiverError}}</p>
+      <div class="frow" *ngIf="player.liabilityWaiver">
+        <button type="button" class="btn btn-dark btn-sm mt-1" (click)="openLiabilityWaiver()">Ver Carta Responsiva</button>
+      </div>
     </div>
   </div>
 </form>
+
+<!--Liability waiver full-screen modal-->
+<div class="modal"
+      tabindex="-1"
+      role="dialog"
+      [ngStyle]="{'display':displayWaiver}">
+  <div class="modal-dialog modal-fullscreen" role="document">
+    <div class="modal-content">
+      <div class="modal-header dark-header">
+        <h5 class="modal-title">Carta Responsiva</h5>
+        <button type="button" class="btn-close" (click)="closeLiabilityWaiver()" aria-label="Close">
+        </button>
+      </div>
+      <div class="modal-body" style="height: 100%;">
+        <div *ngIf="loadingWaiver" class="text-center">
+          <div class="spinner-border text-dark" role="status">
+            <span class="sr-only">Loading...</span>
+          </div>
+        </div>
+        <p *ngIf="waiverError" style="color: red;">{{waiverError}}</p>
+        <iframe *ngIf="!loadingWaiver && waiverSafeUrl && waiverIsPdf" [src]="waiverSafeUrl" style="width: 100%; height: 100%; border: none;"></iframe>
+        <div *ngIf="!loadingWaiver && waiverUrl && !waiverIsPdf" class="text-center" style="height: 100%; overflow: auto;">
+          <img [src]="waiverUrl" alt="Carta Responsiva" style="max-width: 100%;">
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/angular-app/src/app/restricted-area/view-teams/add-player/add-player.component.ts
+++ b/angular-app/src/app/restricted-area/view-teams/add-player/add-player.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { FormBuilder, Validators } from '@angular/forms';
 import { AuthService } from '../../../auth.service';
 import { getCategories } from '../../../interfaces/team';
@@ -6,10 +7,9 @@ import { Category, Player } from '../../../interfaces/player';
 import { DynamoDb } from '../../../aws-clients/dynamodb';
 import { PlayerBuilder } from '../../../Builders/player-builder';
 import { ReporteBuilder } from '../../../Builders/reporte-builder';
-import { S3 } from 'src/app/aws-clients/s3';
+import { S3, LIABILITY_WAIVER_PATH } from 'src/app/aws-clients/s3';
 import { Buffer } from 'buffer';
 import { TOURNAMENT_YEAR } from 'src/app/aws-clients/constants';
-import { DatePipe } from '@angular/common'
 
 @Component({
   selector: 'app-add-player',
@@ -23,7 +23,7 @@ export class AddPlayerComponent {
     private authService: AuthService,
     private playerBuilder: PlayerBuilder,
     private reporteBuilder: ReporteBuilder,
-    private datepipe: DatePipe
+    private sanitizer: DomSanitizer
   ) {
     this.player = {
       id: this.playerId,
@@ -34,6 +34,9 @@ export class AddPlayerComponent {
       height: "",
       weight: "",
       position: "",
+      number: "",
+      curp: "",
+      liabilityWaiver: "",
       birthday: ""
     }
   }
@@ -49,11 +52,21 @@ export class AddPlayerComponent {
   scout_id = this.authService.getUserId();
   scout_name = this.authService.getUserName();
   categories = getCategories();
+  positions = PlayerBuilder.positions;
+  selectedPositions: Record<string, boolean> = {};
   player: Player;
   displayStyle = "none";
   emptyTxt : string = "";
   imageUrl: string | ArrayBuffer | null | undefined = "assets/no-avatar.png";
   blob: Blob | undefined
+
+  waiverToUpload: {data: Buffer, contentType: string} | undefined;
+  waiverError: string = "";
+  displayWaiver = "none";
+  loadingWaiver = false;
+  waiverUrl: string | undefined;
+  waiverSafeUrl: SafeResourceUrl | undefined;
+  waiverIsPdf = false;
 
   async ngOnInit() {
     this.imgToUpload = undefined
@@ -66,8 +79,7 @@ export class AddPlayerComponent {
     if (existingPlayer){
       this.player = existingPlayer;
       console.log("found:", existingPlayer.name);
-      let bday = new Date(this.player.birthday)
-      this.playerForm.controls.bday.setValue(this.datepipe.transform(bday, 'yyyy-MM-dd')!)
+      this.playerForm.controls.bday.setValue(this.player.birthday)
     } else {
       this.player = this.playerBuilder.getEmptyPlayer()
       this.player.id = playerId;
@@ -78,7 +90,13 @@ export class AddPlayerComponent {
     this.playerForm.controls.categoria.setValue(this.player.category)
     this.playerForm.controls.altura.setValue(this.player.height)
     this.playerForm.controls.peso.setValue(this.player.weight)
-    this.playerForm.controls.posicion.setValue(this.player.position)
+    this.playerForm.controls.numero.setValue(this.player.number)
+    this.playerForm.controls.curp.setValue(this.player.curp)
+
+    this.selectedPositions = {};
+    this.player.position.split(',').map(p => p.trim()).filter(p => p).forEach(p => {
+      this.selectedPositions[p] = true;
+    });
 
     if (this.player.imageType){
       await this.s3.downloadFile(this.player.id).then((data) => {
@@ -102,6 +120,10 @@ export class AddPlayerComponent {
 
   }
 
+
+  togglePosition(position: string): void {
+    this.selectedPositions[position] = !this.selectedPositions[position];
+  }
 
   onFileSelected(event: any): void {
     const file: File = event.target.files[0];
@@ -135,14 +157,11 @@ export class AddPlayerComponent {
     this.player.name = this.playerForm.value.nombre!
     this.player.height = this.playerForm.value.altura!
     this.player.weight = this.playerForm.value.peso!
-    this.player.position = this.playerForm.value.posicion!
-    
-    let localDate = new Date(this.playerForm.value.bday!)
-    let bday = new Date(localDate.getTime() + (localDate.getTimezoneOffset() * 60000))
+    this.player.number = this.playerForm.value.numero ?? ""
+    this.player.curp = this.playerForm.value.curp!
+    this.player.position = this.positions.filter(p => this.selectedPositions[p]).join(',')
 
-    console.log("bday: ", bday)
-
-    this.player.birthday = this.datepipe.transform(bday, 'yyyy-MM-dd')!;
+    this.player.birthday = this.playerForm.value.bday!;
   }
 
   async savePlayerPhoto(){
@@ -156,6 +175,68 @@ export class AddPlayerComponent {
       console.log("Player photo uploaded")
       this.imgToUpload = undefined
     }
+  }
+
+  onWaiverSelected(event: any): void {
+    const file: File = event.target.files[0];
+    if (!file) return;
+
+    if (!file.type.startsWith('image/') && file.type !== 'application/pdf') {
+      this.waiverError = "El archivo debe ser una imagen o un PDF.";
+      return;
+    }
+
+    this.waiverError = "";
+    const reader = new FileReader();
+    reader.readAsArrayBuffer(file);
+    reader.onload = () => {
+      this.waiverToUpload = {
+        data: Buffer.from(reader.result as ArrayBuffer),
+        contentType: file.type
+      };
+    };
+  }
+
+  async saveLiabilityWaiver(){
+    if (this.waiverToUpload) {
+      await this.playerBuilder.uploadLiabilityWaiver(
+        this.ddb,
+        this.s3,
+        this.player.id,
+        this.waiverToUpload.data,
+        this.waiverToUpload.contentType
+      );
+      this.player.liabilityWaiver = PlayerBuilder.getLiabilityWaiverFileName(this.player.id);
+      this.waiverToUpload = undefined;
+    }
+  }
+
+  async openLiabilityWaiver(){
+    this.waiverUrl = undefined;
+    this.waiverError = "";
+    this.loadingWaiver = true;
+    this.displayWaiver = "block";
+
+    if (this.player.liabilityWaiver) {
+      const result = await this.s3.downloadFileWithType(this.player.liabilityWaiver, LIABILITY_WAIVER_PATH);
+      if (result) {
+        this.waiverIsPdf = result.contentType === 'application/pdf';
+        const blob = new Blob([result.data as any], {type: result.contentType});
+        this.waiverUrl = URL.createObjectURL(blob);
+        this.waiverSafeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(this.waiverUrl);
+      } else {
+        this.waiverError = "No se pudo cargar la carta responsiva.";
+      }
+    } else {
+      this.waiverError = "No se ha subido una carta responsiva.";
+    }
+    this.loadingWaiver = false;
+  }
+
+  closeLiabilityWaiver(){
+    this.displayWaiver = "none";
+    this.waiverUrl = undefined;
+    this.waiverSafeUrl = undefined;
   }
 }
 

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.html
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.html
@@ -42,12 +42,14 @@
       <div style="min-width: 400px;">
         <table class="row">
             <tr class="row">
-                <th class="col col-7"> <a [routerLink]="">Jugador</a></th>
+                <th class="col col-1"> <a [routerLink]="">#</a></th>
+                <th class="col col-6"> <a [routerLink]="">Jugador</a></th>
                 <th class="col col-3"> <a [routerLink]="">Posición</a></th>
                 <th class="col col-2"> <a [routerLink]=""></a></th>
             </tr>
             <tr class="row" *ngFor="let player of players" [routerLink]="">
-                <td class="col col-7" (click)="editPlayer(player.id)"><u>{{player.name}}{{(player.id === team?.captainId) ? " (Capitán)" : ""}}</u></td>
+                <td class="col col-1" (click)="editPlayer(player.id)">{{player.number}}</td>
+                <td class="col col-6" (click)="editPlayer(player.id)"><u>{{player.name}}{{(player.id === team?.captainId) ? " (Capitán)" : ""}}</u></td>
                 <td class="col col-3" (click)="editPlayer(player.id)">{{player.position}}</td>
                 <td class="col col-2">
                   <button class="btn btn-outline-danger btn-floating m-1" title="Remover jugador" (click)="removePlayer(player.id)" target="_blank" role="button">

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
@@ -411,6 +411,7 @@ export class ViewTeamsComponent {
     console.log("Adding Player:", newPlayer);
     await this.playerBuilder.createPlayer(this.ddb, newPlayer);
     await this.addPlayerViewChild.savePlayerPhoto();
+    await this.addPlayerViewChild.saveLiabilityWaiver();
     console.log(`Saved Player: ${newPlayer.name} - ${newPlayer.id}`);
     await this.loadTeam(this.team!.id);
     this.closeAddPlayerPopup();


### PR DESCRIPTION
- Position is now selected via checkboxes (1-5), stored comma-separated
- Added jersey number attribute with a "#" column in team/participants rosters
- Added CURP attribute (form-only, not shown in roster)
- Added liabilityWaiver ("Carta Responsiva"): image or PDF stored in S3 under liability-waiver/ (root, alongside images/), loaded on demand via a full-screen modal, not fetched with normal player data
- Coerce empty number input to "" and treat stored "null" as empty