### PR TITLE
Consolidate scout features into Evaluar Partido tabs

### DIFF
--- a/angular-app/src/app/restricted-area/evaluacion/evaluacion.component.html
+++ b/angular-app/src/app/restricted-area/evaluacion/evaluacion.component.html
@@ -23,20 +23,6 @@
                   <input *ngIf="this.selectedPlayer.id" style="display:none;" id="photoFile" type="file" (change)="onFileSelected($event)" accept="image/*" maxFileSize="10000000">
                 </div>
                 <div class="col col-12 col-lg-7">
-                  <label class="frow" for="categoria">Categoria:&nbsp;</label>
-                  <div class="frow">
-                      <select id="categorias" formControlName="categoria" (change)="loadTeams()" required>
-                          <option value=""></option>
-                          <option *ngFor="let cat of categories" value="{{cat}}">{{cat}}</option>
-                      </select>
-                  </div>
-                  <label class="frow" for="equipo">Equipo:&nbsp;</label>
-                  <div class="frow">
-                      <select id="equipos" formControlName="equipo" (change)="loadPlayers()" required>
-                          <option value=""></option>
-                          <option *ngFor="let team of teams" value="{{team.name}}">{{team.name}}</option>
-                      </select>
-                  </div>
                   <label class="frow" for="filtroJugador">Jugador:&nbsp;</label>
                   <div class="frow" style="position: relative;">
                       <input id="filtroJugador" type="text" class="form-control" autocomplete="off" [value]="playerFilter"

--- a/angular-app/src/app/restricted-area/evaluacion/evaluacion.component.ts
+++ b/angular-app/src/app/restricted-area/evaluacion/evaluacion.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, ViewChild } from '@angular/core';
+import { Component, ElementRef, Input, OnChanges, SimpleChanges, ViewChild } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { AuthService } from '../../auth.service';
 import { Team, getCategories } from '../../interfaces/team';
@@ -19,7 +19,7 @@ import { TOURNAMENT_YEAR } from 'src/app/aws-clients/constants';
   templateUrl: './evaluacion.component.html',
   styleUrls: ['./evaluacion.component.scss']
 })
-export class EvaluacionComponent {
+export class EvaluacionComponent implements OnChanges {
   imgBuffer: ArrayBuffer|undefined;
   imgType: string|undefined;
 
@@ -31,6 +31,9 @@ export class EvaluacionComponent {
   ) {}
 
   @Input() ddb!: DynamoDb;
+  // Category and team are driven by the shared filters in the parent (evaluar-partido).
+  @Input() category: string | null | undefined = null;
+  @Input() team: string | null | undefined = null;
 
   scout_id = this.authService.getUserId();
   scout_name = this.authService.getUserName();
@@ -123,6 +126,17 @@ export class EvaluacionComponent {
   }
   
   async ngOnInit() {
+  }
+
+  async ngOnChanges(changes: SimpleChanges) {
+    if (changes['category']) {
+      this.evaluationForm.controls['categoria'].setValue(this.category ?? '');
+      await this.loadTeams();
+    }
+    if (changes['team']) {
+      this.evaluationForm.controls['equipo'].setValue(this.team ?? '');
+      await this.loadPlayers();
+    }
   }
 
   async onSubmit() {

--- a/angular-app/src/app/restricted-area/evaluar-partido/evaluar-partido.component.html
+++ b/angular-app/src/app/restricted-area/evaluar-partido/evaluar-partido.component.html
@@ -1,74 +1,211 @@
+<!-- Tab links, shared between the top (large screens) and bottom (phones) bars. -->
+<ng-template #tabLinks>
+    <a class="bottom-tab" [class.active]="activeTab === 'partido'" role="button" (click)="selectTab('partido')">
+        <i class="fas fa-basketball-ball"></i>
+        <span>Partido</span>
+    </a>
+    <a class="bottom-tab" [class.active]="activeTab === 'jugador'" role="button" (click)="selectTab('jugador')">
+        <i class="fas fa-user"></i>
+        <span>Jugador</span>
+    </a>
+    <a class="bottom-tab" [class.active]="activeTab === 'equipos'" role="button" (click)="selectTab('equipos')">
+        <i class="fas fa-users"></i>
+        <span>Equipos</span>
+    </a>
+    <a class="bottom-tab" [class.active]="activeTab === 'estadisticas'" role="button" (click)="selectTab('estadisticas')">
+        <i class="fas fa-chart-line"></i>
+        <span>Stats</span>
+    </a>
+</ng-template>
+
+<!-- Top tab bar: large screens (laptops/tablets) only. -->
+<nav class="tab-bar top-tab-bar d-none d-md-flex" *ngIf="!loading">
+    <ng-container *ngTemplateOutlet="tabLinks"></ng-container>
+</nav>
+
 <div class="row justify-content-md-center">
-    
+
     <div class="spinner-border text-light" role="status" *ngIf="loading">
         <span class="sr-only">Loading...</span>
     </div>
-    <div class="row mainpanel" *ngIf="!loading">
-        <div *ngIf="!isTeamSelected">
+    <div class="row mainpanel tab-content-panel" *ngIf="!loading">
 
-            <form [formGroup]="filterForm" *ngIf="!isTeamSelected">
-                <div class="row">
-                    <div class="col col-md-3 col-12">
-                        <div class="row">
-                            <label for="days">Day:</label>
-                        </div>
-                        <div class="row">
-                            <div class="filterPadding">
-                                <select class="col-12" id="days" formControlName="day" (change)="applyFilters()" required>
-                                    <option value={{null}}></option>
-                                    <option *ngFor="let day of days" value="{{day}}">{{day}}</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col col-md-3 col-12">
-                        <div class="row">
-                            <label for="gyms">Gimnasio</label>
-                        </div>
-                        <div class="row">
-                            <div class="filterPadding">
-                                <select class="col-12" id="gyms" formControlName="gym" (change)="applyFilters()" require>
-                                    <option value={{null}}></option>
-                                    <option *ngFor="let gym of gyms" value="{{gym.id}}">{{gym.name}}</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
+        <!-- Shared filters (Category + Equipo) — hidden on the statistics tab, which has its own filters -->
+        <form class="filter-bar" [formGroup]="filterForm" *ngIf="!isScouting && !isTeamSelected && activeTab !== 'estadisticas'">
+            <div class="row g-2">
+                <div class="col-6 col-md-2">
+                    <select class="form-select" id="category" formControlName="cat" (change)="applyCategoryFilter()" required>
+                        <option [ngValue]="null">Categoría</option>
+                        <option value="aprendiz">Aprendiz</option>
+                        <option value="elite">Elite</option>
+                    </select>
                 </div>
-            </form>
-
-            <div class="row marcadorItem" *ngFor="let match of filteredMatches" >
-                <div class="col col-12">
-                    <h5>
-                        {{match.juego}} ({{match.category}}) - <a href="https://www.google.com/maps/search/?api=1&query_place_id={{match.location.place_id}}&query={{match.location.address}}">{{match.location.name}}</a>
-                    </h5>
-                    <h6>{{match.time}}</h6>
+                <div class="col-6 col-md-2" *ngIf="activeTab !== 'equipos'">
+                    <select class="form-select" id="teams" formControlName="equipo" (change)="applyFilters()">
+                        <option [ngValue]="null">Equipo</option>
+                        <option *ngFor="let equipo of filteredTeams" value="{{equipo.name}}">{{equipo.name}}</option>
+                    </select>
                 </div>
-                
 
-                <div class="col col-2 col-md-1">
-                    <a class="btn btn-outline-light btn-floating m-1" role="button" (click)="edit(match.homeTeam)">
-                        <i class="fas fa-regular fa-pen"></i>
+                <!-- Evaluar Partido specific filters -->
+                <div class="col-6 col-md-2" *ngIf="activeTab === 'partido'">
+                    <select class="form-select" id="days" formControlName="day" (change)="applyFilters()">
+                        <option [ngValue]="null">Día</option>
+                        <option *ngFor="let day of days" value="{{day}}">{{day}}</option>
+                    </select>
+                </div>
+                <div class="col-6 col-md-2" *ngIf="activeTab === 'partido'">
+                    <select class="form-select" id="gyms" formControlName="gym" (change)="applyFilters()">
+                        <option [ngValue]="null">Gimnasio</option>
+                        <option *ngFor="let gym of gyms" value="{{gym.id}}">{{gym.name}}</option>
+                    </select>
+                </div>
+            </div>
+            <div class="row mt-2">
+                <div class="col-12">
+                    <button class="btn btn-outline-light btn-sm" type="button" (click)="clearFilters()" title="Limpiar filtros" aria-label="Limpiar filtros">
+                        <i class="fas fa-rotate-left"></i>
+                    </button>
+                </div>
+            </div>
+        </form>
+
+        <div *ngIf="activeTab === 'partido' && !isTeamSelected">
+        <div class="mt-4" *ngIf="!isScouting">
+
+            <!-- Read-only match card: same layout as the scouting card, but not editable. -->
+            <div class="match-card match-card--readonly mb-3" *ngFor="let match of filteredMatches">
+                <!-- Escautear replaces the save button (top right). -->
+                <button class="btn btn-warning btn-floating match-card__save" title="Escautear" role="button" (click)="scout(match)">
+                    <i class="fas fa-binoculars"></i>
+                </button>
+                <!-- Category tag pinned top-left. -->
+                <span class="match-badge">{{match.category}}</span>
+
+                <div class="match-card__meta">
+                    <!-- Primary line: which game + when. -->
+                    <div class="match-card__title">
+                        <span class="match-game">{{match.juego}}</span>
+                        <span class="match-time"><i class="fas fa-clock"></i>&nbsp;{{match.time}}</span>
+                    </div>
+                    <!-- Secondary line: where (gym) — clickable. -->
+                    <a class="match-location" target="_blank" rel="noopener"
+                       href="https://www.google.com/maps/search/?api=1&query_place_id={{match.location.place_id}}&query={{match.location.address}}">
+                        <i class="fas fa-location-dot"></i>&nbsp;{{match.location.name}}
                     </a>
                 </div>
-                <div class="col col-3 col-md-4">{{match.homeTeam.name}}</div>
-                <div class="col col-2"> X </div>
-                <div class="col col-3 col-md-4">{{match.visitorTeam.name}}</div>
-                <div class="col col-2 col-md-1" > 
-                    <a class="btn btn-outline-light btn-floating m-1" role="button" (click)="edit(match.visitorTeam)">
-                        <i class="fas fa-regular fa-pen"></i>
-                    </a>
-                </div>
 
-                <div class="col col-1"></div>
-                <div class="col col-4">{{match.homePoints}}</div>
-                <div class="col col-2"></div>
-                <div class="col col-4">{{match.visitorPoints}}</div>
-                <div class="col col-1"></div>
+                <div class="match-card__scoreboard">
+                    <div class="match-team">
+                        <div class="match-team__name">{{match.homeTeam.name}}</div>
+                        <div class="match-score match-score--static">{{match.homePoints}}</div>
+                    </div>
+                    <span class="match-vs">×</span>
+                    <div class="match-team">
+                        <div class="match-team__name">{{match.visitorTeam.name}}</div>
+                        <div class="match-score match-score--static">{{match.visitorPoints}}</div>
+                    </div>
+                </div>
             </div>
         </div>
+        <div class="row" *ngIf="isScouting">
+            <form [formGroup]="marcadorForm" (ngSubmit)="submitScore()">
+
+                <!-- Toolbar: back to the match list. -->
+                <div class="scout-toolbar">
+                    <button class="btn btn-outline-light btn-floating" title="Volver a Partidos" type="button" (click)="closeScout()">
+                        <i class="fas fa-arrow-left"></i>
+                    </button>
+                </div>
+
+                <!-- Modernized match info card -->
+                <div class="match-card">
+                    <!-- Save lives inside the card (top right) since it persists this match's info. -->
+                    <button class="btn btn-warning btn-floating match-card__save" title="Guardar" type="submit">
+                        <i class="fas fa-floppy-disk"></i>
+                    </button>
+                    <!-- Category tag pinned top-left, mirroring the save button top-right. -->
+                    <span class="match-badge">{{scoutingMatch.category}}</span>
+
+                    <div class="match-card__meta">
+                        <!-- Primary line: which game + when. -->
+                        <div class="match-card__title">
+                            <span class="match-game">{{scoutingMatch.juego}}</span>
+                            <span class="match-time"><i class="fas fa-clock"></i>&nbsp;{{scoutingMatch.time}}</span>
+                        </div>
+                        <!-- Secondary line: where (gym). -->
+                        <a class="match-location" target="_blank" rel="noopener"
+                           href="https://www.google.com/maps/search/?api=1&query_place_id={{scoutingMatch.location.place_id}}&query={{scoutingMatch.location.address}}">
+                            <i class="fas fa-location-dot"></i>&nbsp;{{scoutingMatch.location.name}}
+                        </a>
+                    </div>
+
+                    <div class="match-card__scoreboard">
+                        <div class="match-team" [class.match-team--active]="editingTeam.id == scoutingMatch.homeTeam.id">
+                            <div class="match-team__name" (click)="selectScoutingTeam(scoutingMatch.homeTeam)">{{scoutingMatch.homeTeam.name}}</div>
+                            <input class="match-score" id="homescore" type="number" formControlName="homeScore" value="{{scoutingMatch.homePoints}}">
+                        </div>
+                        <span class="match-vs">×</span>
+                        <div class="match-team" [class.match-team--active]="editingTeam.id == scoutingMatch.visitorTeam.id">
+                            <div class="match-team__name" (click)="selectScoutingTeam(scoutingMatch.visitorTeam)">{{scoutingMatch.visitorTeam.name}}</div>
+                            <input class="match-score" id="visitorscore" type="number" formControlName="visitorScore" value="{{scoutingMatch.visitorPoints}}">
+                        </div>
+                    </div>
+
+                </div>
+
+            </form>
+
+            <div class="row">
+                <div class="col col-12">
+                    <img [src]="this.editingTeam.imageUrl" class="rounded scout-team-logo">
+                    <h1>{{this.editingTeam.name}}</h1>
+                    <br>
+                    <div class="col col-12">
+                        <button *ngFor="let player of players" class="player-card btn col-6 col-md-2" (click)="evalPlayer(player)">
+                            <img width="100%" [src]="player.imageUrl" class="rounded">
+                            <p>{{player.name}}</p>
+                            <p>Posición: {{player.position}}</p>
+                            <p>Número: {{player.number}}</p>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        </div>
+
+        <div *ngIf="activeTab === 'jugador'">
+            <app-evaluacion *ngIf="filterForm.value.equipo"
+                [ddb]="ddb" [s3]="s3" [category]="evaluacionCategory" [team]="filterForm.value.equipo"></app-evaluacion>
+            <p class="text-center text-light mt-4" *ngIf="!filterForm.value.equipo">
+                <i class="fas fa-arrow-up"></i>&nbsp;Selecciona un equipo para evaluar jugadores.
+            </p>
+        </div>
+
+        <div *ngIf="activeTab === 'equipos' && !isTeamSelected">
+            <div class="scroll-container">
+                <div style="min-width: 400px;">
+                    <table class="row team-list-table">
+                        <tr class="row">
+                            <th class="col col-6">Equipo</th>
+                            <th class="col col-6">Categoria</th>
+                        </tr>
+                        <tr class="row" *ngFor="let team of filteredTeams" [routerLink]="" (click)="edit(team)">
+                            <td class="col col-6"><u>{{team.name}}</u></td>
+                            <td class="col col-6">{{team.category}}</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <div *ngIf="activeTab === 'estadisticas' && !isTeamSelected">
+            <app-resultados-evaluacion [ddb]="ddb"></app-resultados-evaluacion>
+        </div>
+
+        <!-- Team detail view (shared): team players with photos, no match info -->
         <div *ngIf="isTeamSelected">
-            <button class="btn btn-outline-danger btn-floating m-1" title="Volver a Partidos" (click)="closeTeam()" target="_blank" role="button">
+            <button class="btn btn-outline-danger btn-floating m-1" title="Volver a Equipos" (click)="closeTeam()" role="button">
                 <i class="fas fa-arrow-left"></i>
             </button>
             <br><br>
@@ -90,7 +227,12 @@
         </div>
     </div>
 </div>
-    
+
+<!-- Bottom tab bar: phones only. -->
+<nav class="tab-bar bottom-tab-bar d-flex d-md-none" *ngIf="!loading">
+    <ng-container *ngTemplateOutlet="tabLinks"></ng-container>
+</nav>
+
 <!--eval player-->
 <div class="modal"
   tabindex="-1"

--- a/angular-app/src/app/restricted-area/evaluar-partido/evaluar-partido.component.scss
+++ b/angular-app/src/app/restricted-area/evaluar-partido/evaluar-partido.component.scss
@@ -35,3 +35,298 @@ fieldset {
     background-color: $bg-color2;
     border-color: $bg-color1;
 }
+
+// Team list table — matches "Equipos Registrados" (list-teams).
+table {
+    color: black;
+}
+
+td, th {
+    text-align: left;
+    border: 0px solid #dddddd;
+}
+
+td {
+    color: $text-color2;
+    background-color: $bg-color2;
+    padding: 8px;
+}
+
+tr{
+    border-bottom: 2px solid $header-color2;
+}
+
+th {
+    color: $text-color2;
+    background-color: $header-color2;
+    padding: 8px;
+}
+
+.team-list-table .row{
+    --bs-gutter-x: 0%;
+}
+
+.team-list-table tr{
+    cursor: pointer;
+}
+
+.team-toggle{
+    cursor: pointer;
+}
+
+.team-selected{
+    font-weight: bold;
+    text-decoration: underline;
+}
+
+// Shared tab-bar look — same format whether shown on top or bottom.
+// Sticky (not fixed) so the bar hugs the viewport edge while scrolling
+// but settles within the page instead of overlaying the footer.
+.tab-bar{
+    position: sticky;
+    z-index: 1030;
+    background-color: $bg-color1;
+
+    .bottom-tab{
+        flex: 1 1 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.15rem;
+        padding: 0.6rem 0.25rem;
+        color: $bg-color2;
+        text-decoration: none;
+        cursor: pointer;
+
+        i{
+            font-size: 1.35rem;
+        }
+
+        span{
+            font-size: 0.8rem;
+        }
+    }
+
+    .bottom-tab.active{
+        color: $header-color1;
+        font-weight: bold;
+    }
+}
+
+// Top bar: large screens (laptops/tablets).
+.top-tab-bar{
+    top: 0;
+    border-bottom: 2px solid $header-color1;
+}
+
+// Bottom bar: phones. Fixed to the viewport bottom.
+.bottom-tab-bar{
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    border-top: 2px solid $header-color1;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+// Reserve space on phones so the fixed bottom bar never covers page content.
+@media (max-width: 767.98px){
+    .tab-content-panel{
+        padding-bottom: calc(4.5rem + env(safe-area-inset-bottom, 0px));
+    }
+}
+
+// Scouting toolbar: back to the match list, above the match card.
+.scout-toolbar{
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    margin-bottom: 0.75rem;
+}
+
+// Modernized match info card shown while scouting.
+.match-card{
+    position: relative;
+    background-color: $bg-color15;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+
+    // Save button pinned to the card's top-right corner.
+    .match-card__save{
+        position: absolute;
+        top: 0.75rem;
+        right: 0.75rem;
+        z-index: 1;
+    }
+
+    // Stacked header: primary title line, then the gym on its own line.
+    .match-card__meta{
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.25rem;
+        color: $bg-color2;
+        // Clear the top-left badge and top-right save button.
+        padding-top: 1.75rem;
+    }
+
+    .match-card__title{
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        justify-content: center;
+        gap: 0.5rem 0.75rem;
+    }
+
+    // Category tag pinned to the card's top-left corner.
+    .match-badge{
+        position: absolute;
+        top: 0.75rem;
+        left: 0.75rem;
+        z-index: 1;
+        background-color: $header-color1;
+        color: $bg-color1;
+        font-weight: 700;
+        text-transform: capitalize;
+        border-radius: 999px;
+        padding: 0.15rem 0.7rem;
+        font-size: 0.8rem;
+    }
+
+    .match-game{
+        font-weight: 600;
+    }
+
+    .match-time{
+        color: $bg-color2;
+        font-size: 0.9rem;
+        opacity: 0.9;
+    }
+
+    // Gym is a link — make it obviously clickable.
+    .match-location{
+        color: $header-color1;
+        text-decoration: underline;
+        font-size: 0.9rem;
+        cursor: pointer;
+    }
+
+    .match-location:hover{
+        color: $header-color1;
+        opacity: 0.8;
+    }
+
+    .match-card__scoreboard{
+        display: flex;
+        align-items: flex-start;
+        justify-content: center;
+        gap: 1rem;
+        margin-top: 1rem;
+    }
+
+    .match-team{
+        flex: 1 1 0;
+        max-width: 12rem;
+        text-align: center;
+        border: 1px solid transparent;
+        border-radius: 0.5rem;
+        padding: 0.5rem;
+        transition: border-color 0.15s ease, background-color 0.15s ease;
+    }
+
+    .match-team--active{
+        border-color: $header-color1;
+        background-color: rgba(254, 215, 56, 0.12);
+    }
+
+    .match-team__name{
+        color: $bg-color2;
+        font-weight: 600;
+        cursor: pointer;
+        margin-bottom: 0.5rem;
+    }
+
+    .match-team--active .match-team__name{
+        color: $header-color1;
+    }
+
+    .match-score{
+        width: 100%;
+        text-align: center;
+        border-radius: 0.5rem;
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        background-color: rgba(255, 255, 255, 0.95);
+        color: $bg-color1;
+        font-weight: 700;
+        padding: 0.35rem;
+    }
+
+    .match-score:focus{
+        outline: none;
+        border-color: $header-color1;
+        box-shadow: 0 0 0 0.2rem rgba(254, 215, 56, 0.35);
+    }
+
+    // Read-only score on the landing card: noticeable but clearly not editable.
+    .match-score--static{
+        border-color: transparent;
+        background-color: transparent;
+        color: $bg-color2;
+        font-size: 1.75rem;
+        line-height: 1;
+    }
+
+    .match-vs{
+        align-self: center;
+        color: $header-color1;
+        font-size: 1.5rem;
+        font-weight: 700;
+    }
+}
+
+// Read-only landing card: team names are not selectable.
+.match-card--readonly{
+    .match-team__name{
+        cursor: default;
+    }
+}
+
+// Scouting team logo: 10% larger than the prior col-3 / col-md-1 sizing,
+// with spacing between the match info card and the logo.
+.scout-team-logo{
+    margin-top: 1.5rem;
+    width: 27.5%;      // was col-3 (25%)
+
+    @media (min-width: 768px){
+        width: 9.17%;  // was col-md-1 (~8.33%)
+    }
+}
+
+// Modern filter bar.
+.filter-bar{
+    background-color: $bg-color15;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 0.75rem;
+    padding: 1rem;
+
+    // Spacing between the top tabs and the filters on large screens.
+    @media (min-width: 768px){
+        margin-top: 1.5rem;
+    }
+
+    // Single-row selects: the filter name lives in the placeholder option and
+    // disappears once a value is chosen.
+    .form-select{
+        border-radius: 0.5rem;
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        background-color: rgba(255, 255, 255, 0.95);
+        color: $bg-color1;
+    }
+
+    .form-select:focus{
+        border-color: $header-color1;
+        box-shadow: 0 0 0 0.2rem rgba(254, 215, 56, 0.35);
+    }
+}

--- a/angular-app/src/app/restricted-area/evaluar-partido/evaluar-partido.component.ts
+++ b/angular-app/src/app/restricted-area/evaluar-partido/evaluar-partido.component.ts
@@ -15,6 +15,7 @@ import { S3 } from 'src/app/aws-clients/s3';
 import { Skill, Skills } from 'src/app/interfaces/reporte';
 import { ReporteBuilder } from 'src/app/Builders/reporte-builder';
 import { AuthService } from 'src/app/auth.service';
+import { filterMatches } from 'src/app/utils/utils';
 
 
 @Component({
@@ -39,9 +40,13 @@ export class EvaluarPartidoComponent implements OnInit {
 
   equipos : Team[] = [];
   filteredMatches: Match[] = [];
+  filteredTeams: Team[] = [];
 
+  activeTab: 'partido' | 'jugador' | 'equipos' | 'estadisticas' = 'partido';
   isTeamSelected: boolean = false;
   isEvaluatingPlayer: boolean = false;
+  isScouting: boolean = false;
+  scoutingMatch: Match = {location: {id: "", name: ""}, time: "", juego: "", visitorTeam: {id: "", name: "", category: ""}, visitorPoints: "0", homeTeam: {id: "", name: "", category: ""}, homePoints:"0"};
   loading: boolean = true;
   editingTeam: MatchTeamWithPhoto = {id: "", name: "", category: "", imageUrl: ""};
   displayEvalPlayer = "none";
@@ -89,60 +94,82 @@ export class EvaluarPartidoComponent implements OnInit {
     visitorScore : [0]
   });
 
+  // Category for the Jugador tab: use the selected filter, or derive it from
+  // the selected team so a player can be evaluated without picking a category.
+  get evaluacionCategory(): string | null {
+    if (this.filterForm.value.cat) {
+      return this.filterForm.value.cat;
+    }
+    const teamName = this.filterForm.value.equipo;
+    if (teamName) {
+      const team = this.equipos.find(t => t.name == teamName);
+      return team?.category ?? null;
+    }
+    return null;
+  }
+
   async ngOnInit() {
     this.gyms = await this.gymBuilder.getListOfGyms(this.ddb, TOURNAMENT_YEAR);
     await this.loadMatches();
-  }  
+  }
+
+  selectTab(tab: 'partido' | 'jugador' | 'equipos' | 'estadisticas') {
+    this.activeTab = tab;
+    // Leaving the Equipos tab should close any open team detail view.
+    if (tab !== 'equipos') {
+      this.isTeamSelected = false;
+    }
+  }
+
   
   async loadMatches(){
     this.allMatches = await this.matchBuilder.getListOfMatch(this.ddb, TOURNAMENT_YEAR)
     this.equipos = await this.teamBuilder.getTeams(this.ddb)
-    this.filteredMatches = this.allMatches;
-    this.filteredMatches = this.filteredMatches.sort((a, b) => (a.day! + a.time!).localeCompare(b.day! + b.time!))
+    this.filteredMatches = this.allMatches.sort((a, b) => (a.day! + a.time!).localeCompare(b.day! + b.time!));
+    this.filteredTeams = this.equipos;
+    this.applyCategoryFilter();
     this.loading = false;
   }
 
-  applyFilters() {
+  applyCategoryFilter() {
     this.filteredMatches = this.allMatches;
+    this.filteredTeams = this.equipos;
 
+    let cat = this.filterForm.value.cat
+    console.log(`Applying filter`, cat);
 
-    let day = "";
-    if(this.filterForm.value.day != null){
-      day = this.filterForm.value.day;
+    if(cat){
+      this.filteredMatches = this.filteredMatches.filter(match => match.category == cat);
+      this.filteredTeams = this.filteredTeams.filter(team => team.category == cat);
+    }
+    // if category is changed we should clear existing filter on teams because teams
+    // only exist for a specific category
+    this.filterForm.get('equipo')?.reset()
+    this.applyFilters(this.filteredMatches);
+  }
+
+  clearFilters() {
+    this.filterForm.reset();
+    this.applyCategoryFilter();
+  }
+
+  applyFilters(categoryMatches: Match[] | null = null) {
+    let cat = this.filterForm.value.cat;
+    let day = this.filterForm.value.day;
+    let gym = this.filterForm.value.gym;
+    let team = this.filterForm.value.equipo;
+    console.log('Applying filters', cat, day, gym, team);
+
+    if (!cat && !day && !gym && !team) {
+      this.filteredMatches = this.allMatches;
+      return;
     }
 
-    if(day != ""){
-      let matches : Match[] = []
-      this.filteredMatches.forEach(
-        async (match) => {
-          if(match.day == day){
-            matches.push(match);
-          }
-        }
-      );
-      this.filteredMatches = matches;
-    }
+    let matches: Match[] = this.allMatches;
+    if(categoryMatches) matches = categoryMatches;
+    else if(cat) matches = this.allMatches.filter(match => match.category == cat);
 
-    let gym = "";
-    if(this.filterForm.value.gym != null){
-      gym = this.filterForm.value.gym;
-    }
-
-    if(gym != ""){
-      let matches : Match[] = []
-      this.filteredMatches.forEach(
-        async (match) => {
-          if(match.location.id == gym){
-            matches.push(match);
-          }
-        }
-      );
-      this.filteredMatches = matches;
-    }
-
-    this.filteredMatches = this.filteredMatches.sort((a, b) => (a.day! + a.time!).localeCompare(b.day! + b.time!))
-    console.log(day);
-    console.log(gym);
+    this.filteredMatches = filterMatches(matches, day, gym, team);
   }
 
   async onSubmit() {
@@ -167,6 +194,56 @@ export class EvaluarPartidoComponent implements OnInit {
     this.displayStyle = "none";
   }
   
+
+  async scout(match:Match){
+    this.scoutingMatch = match;
+    if(match.homePoints){
+      this.marcadorForm.controls.homeScore.setValue(Number(match.homePoints));
+    }
+    if(match.visitorPoints){
+      this.marcadorForm.controls.visitorScore.setValue(Number(match.visitorPoints));
+    }
+    this.isScouting = true;
+    // Load the left (home) team by default so its players show under the match info.
+    await this.selectScoutingTeam(match.homeTeam);
+  }
+
+  async selectScoutingTeam(team:MatchTeam){
+    this.editingTeam = team as MatchTeamWithPhoto;
+    await this.loadTeam(this.editingTeam.id);
+  }
+
+  submitScore(){
+    let id = "";
+    if(this.scoutingMatch.id){
+      id = this.scoutingMatch.id;
+    }
+    let hs = "";
+    if(this.marcadorForm.value.homeScore){
+      hs = this.marcadorForm.value.homeScore.toString();
+    }
+    let vs = "";
+    if(this.marcadorForm.value.visitorScore){
+      vs = this.marcadorForm.value.visitorScore.toString();
+    }
+    this.matchBuilder.submit(this.ddb, id, hs, vs).then(
+      (rs) => {
+        this.loadMatches();
+      }
+    );
+    // Keep the scores on the scouting page after saving (don't close the view).
+    this.scoutingMatch.homePoints = hs;
+    this.scoutingMatch.visitorPoints = vs;
+  }
+
+  closeScout(){
+    this.isScouting = false;
+    this.scoutingMatch = {location: {id: "", name: ""}, time: "", juego: "", visitorTeam: {id: "", name: "", category: ""}, visitorPoints: "0", homeTeam: {id: "", name: "", category: ""}, homePoints:"0"};
+    this.marcadorForm.reset();
+    this.editingTeam = {id: "", name: "", category: "", imageUrl: ""};
+    this.players = [];
+    this.team = undefined;
+  }
 
   async edit(team:MatchTeam){
     this.editingTeam = team as MatchTeamWithPhoto;

--- a/angular-app/src/app/restricted-area/restricted-area.component.html
+++ b/angular-app/src/app/restricted-area/restricted-area.component.html
@@ -22,7 +22,7 @@
                 </div>
 
                 <div *ngIf="registrationYear">
-                    <select #feature (change)="changeFeature(feature.value)">
+                    <select #feature [value]="selectedFeature" (change)="changeFeature(feature.value)" *ngIf="menuItems.length > 0">
                         <option *ngFor="let menuItem of menuItems" value="{{menuItem.value}}">{{menuItem.text}}</option>
                     </select>
                     <br>

--- a/angular-app/src/app/restricted-area/restricted-area.component.ts
+++ b/angular-app/src/app/restricted-area/restricted-area.component.ts
@@ -55,6 +55,7 @@ export class RestrictedAreaComponent {
     loading = true;
 
     menuItems: MenuItem[] = [];
+    selectedFeature: string = "";
     validationMsg: string = "";
 
     constructor(private fb:FormBuilder, 
@@ -137,20 +138,16 @@ export class RestrictedAreaComponent {
 
       this.menuItems = []
       if(this.isAdmin){
+        // Scout features (Marcadores, Estadisticas de Evaluacion) now live as
+        // tabs inside Evaluar Partido, so only admins keep a dropdown — and it
+        // includes "Evaluar Partido" so they can navigate back to it.
         this.menuItems = this.menuItems.concat([
           {value: "addGym", text: "Add Gym"},
           {value: "addMatch", text: "Add Match"},
           {value: "editMatch", text: "Edit Match"},
-          {value: "evaluarPartido", text: " Evaluar Partido"},
+          {value: "evaluarPartido", text: "Scouting"},
           {value: "listPlayers", text: "Jugadores Registrados"},
           {value: "viewUsers", text: "Usuarios Registrados"}
-        ]);
-      }
-      if(this.isScout){
-        this.menuItems = this.menuItems.concat([
-          {value: "evaluar", text: " Evaluar Jugador"},
-          {value: "resultados", text: "Estadisticas de Evaluacion"},
-          {value: "marcadores", text: "Marcadores"}
         ]);
       }
       if(this.isCoach){
@@ -176,7 +173,9 @@ export class RestrictedAreaComponent {
 
       console.log("Reloaded");
 
-      this.changeFeature(this.menuItems[0].value);
+      // Scouts (including admins) land on Evaluar Partido by default.
+      let landingFeature = this.isScout ? "evaluarPartido" : this.menuItems[0].value;
+      this.changeFeature(landingFeature);
     }
 
     async onRenewRegistration(code: string){
@@ -187,7 +186,8 @@ export class RestrictedAreaComponent {
     }
 
     changeFeature(feature: string){
-      switch(feature) { 
+      this.selectedFeature = feature;
+      switch(feature) {
         case 'evaluar': { 
            this.showEvaluacion()
            break; 


### PR DESCRIPTION
- Restrict dropdown menu to admins; add a 'Scouting' entry to return to Evaluar Partido, and hide the dropdown for pure scouts
- Modernize the scouting match info as a card (category tag, title line, clickable gym, scoreboard) with an icon-only save pinned top-right
- Give the Partido landing page a read-only match card with a binoculars Escautear action and static, non-editable scores
- Keep the scout on the scouting page after saving a match score
- Allow evaluating players in the Jugador tab by team alone, deriving the category from the selected team