### PR TITLE
Allow editing player number in scouting; refine team logo sizing

### DIFF
--- a/angular-app/src/app/Builders/player-builder.ts
+++ b/angular-app/src/app/Builders/player-builder.ts
@@ -28,6 +28,22 @@ export class PlayerBuilder {
         await ddb.updateItem(key, updateExpression, expressionAttributeNames, expressionAttributeValues);
     }
 
+    async updatePlayerNumber(ddb: DynamoDb, playerId: string, number: string) {
+        let key = {
+            [PK_KEY]: {S: `${PlayerKey.PREFIX}.${playerId}`},
+            [SK_KEY]: {S: `${PlayerKey.PREFIX}.data`}
+        };
+        let updateExpression = 'SET #numattr = :val';
+        let expressionAttributeNames: Record<string, string> = {
+            '#numattr': `${PlayerKey.NUMBER}`,
+        };
+        let expressionAttributeValues: Record<string, AttributeValue> = {
+            ':val': {S: number},
+        };
+
+        await ddb.updateItem(key, updateExpression, expressionAttributeNames, expressionAttributeValues);
+    }
+
     static getLiabilityWaiverFileName(playerId: string): string {
         return `liability-waiver-${playerId}`;
     }

--- a/angular-app/src/app/restricted-area/evaluacion/evaluacion.component.html
+++ b/angular-app/src/app/restricted-area/evaluacion/evaluacion.component.html
@@ -45,7 +45,12 @@
                   <label class="frow" for="edad">Posicion Registrada:&nbsp;</label>
                   <input class="frow" disabled id="position" type="text" value="{{selectedPlayer.position}}">
                   <label class="frow" for="numero">Número:&nbsp;</label>
-                  <input class="frow" disabled id="numero" type="number" value="{{selectedPlayer.number}}">
+                  <div class="frow" style="display: flex; gap: 0.5rem; align-items: center;">
+                    <input #numeroInput id="numero" type="number" [value]="selectedPlayer.number" [disabled]="!selectedPlayer.id">
+                    <button type="button" class="btn btn-sm btn-warning" [disabled]="!selectedPlayer.id" (click)="savePlayerNumber(numeroInput.value)" title="Guardar número">
+                      <i class="fas fa-floppy-disk"></i>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/angular-app/src/app/restricted-area/evaluacion/evaluacion.component.ts
+++ b/angular-app/src/app/restricted-area/evaluacion/evaluacion.component.ts
@@ -154,6 +154,22 @@ export class EvaluacionComponent implements OnChanges {
     this.openPopup();
   }
 
+  async savePlayerNumber(number: string) {
+    if (!this.selectedPlayer.id) return;
+    try {
+      await this.playerBuilder.updatePlayerNumber(this.ddb, this.selectedPlayer.id, number);
+      this.selectedPlayer.number = number;
+      // Keep the in-memory team list in sync so the filter/list reflects it.
+      const p = this.teamplayers.find(tp => tp.id == this.selectedPlayer.id);
+      if (p) p.number = number;
+      this.submitReportMessage = "Número actualizado";
+    } catch (err) {
+      this.submitReportMessage = `Error guardando número. Contacta a Paco.\n${err}`;
+      console.error("Error updating player number", err);
+    }
+    this.openPopup();
+  }
+
   async loadTeams() {
     this.teams = []
     this.selectedCategoria = this.evaluationForm.value.categoria!

--- a/angular-app/src/app/restricted-area/scouting/scouting.component.html
+++ b/angular-app/src/app/restricted-area/scouting/scouting.component.html
@@ -28,10 +28,15 @@
             <br>
             <div class="col col-12">
                 <button *ngFor="let player of players" class="player-card btn col-6 col-md-2" (click)="evalPlayer(player)">
-                    <img width="100%" [src]="player.imageUrl" class="rounded">
-                    <p>{{player.name}}</p>
-                    <p>Posición: {{player.position}}</p>
-                    <p>Número: {{player.number}}</p>
+                    <img [src]="player.imageUrl" class="rounded player-card__img">
+                    <p class="player-card__name">
+                        <span class="player-card__number">#{{player.number}}</span>
+                        {{player.name | slice:0:15}}{{player.name.length > 15 ? '…' : ''}}
+                    </p>
+                    <p class="player-card__positions">
+                        <i class="fas fa-basketball-ball"></i>
+                        <span class="player-card__pos" *ngFor="let pos of player.position.split(',')">{{pos.trim()}}</span>
+                    </p>
                 </button>
             </div>
         </div>
@@ -210,7 +215,7 @@
         </div>
 
         <!-- Team detail view (shared): team players with photos, no match info -->
-        <div *ngIf="isTeamSelected">
+        <div *ngIf="isTeamSelected" class="team-roster--equipos">
             <div class="scout-toolbar">
                 <button class="btn btn-outline-danger btn-floating" title="Volver a Equipos" (click)="closeTeam()" role="button">
                     <i class="fas fa-arrow-left"></i>
@@ -261,7 +266,12 @@
                         <label class="frow" for="position">Posicion Registrada:&nbsp;</label>
                         <input class="frow" disabled id="position" type="text" value="{{selectedPlayer!.position}}">
                         <label class="frow" for="numero">Número:&nbsp;</label>
-                        <input class="frow" disabled id="numero" type="number" value="{{selectedPlayer!.number}}">
+                        <div class="frow" style="display: flex; gap: 0.5rem; align-items: center;">
+                          <input #numeroInput id="numero" type="number" [value]="selectedPlayer!.number" [disabled]="!selectedPlayer!.id">
+                          <button type="button" class="btn btn-sm btn-warning" [disabled]="!selectedPlayer!.id" (click)="savePlayerNumber(numeroInput.value)" title="Guardar número">
+                            <i class="fas fa-floppy-disk"></i>
+                          </button>
+                        </div>
                     </div>
                     </div>
                 </div>

--- a/angular-app/src/app/restricted-area/scouting/scouting.component.scss
+++ b/angular-app/src/app/restricted-area/scouting/scouting.component.scss
@@ -34,6 +34,65 @@ fieldset {
 .player-card{
     background-color: $bg-color2;
     border-color: $bg-color1;
+    // Every card is the same height regardless of name/position content.
+    display: inline-flex;
+    flex-direction: column;
+    vertical-align: top;
+
+    // Uniform square image regardless of the source photo's aspect ratio.
+    .player-card__img{
+        width: 100%;
+        aspect-ratio: 1 / 1;
+        object-fit: cover;
+    }
+
+    // Single line so a long name never wraps and grows the card.
+    .player-card__name{
+        margin: 0.4rem 0 0.2rem;
+        font-weight: 600;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    // Jersey number badge that leads the name.
+    .player-card__number{
+        display: inline-block;
+        background-color: $bg-color1;
+        color: $bg-color2;
+        border-radius: 0.35rem;
+        padding: 0 0.35rem;
+        margin-right: 0.25rem;
+        font-weight: 700;
+        font-size: 0.85rem;
+    }
+
+    // Positions as compact pills (values are just 1–5). Single line so the
+    // card height stays constant.
+    .player-card__positions{
+        display: flex;
+        flex-wrap: nowrap;
+        align-items: center;
+        justify-content: center;
+        gap: 0.25rem;
+        margin: 0;
+        overflow: hidden;
+
+        i{
+            color: $bg-color1;
+            font-size: 0.85rem;
+            margin-right: 0.1rem;
+        }
+    }
+
+    .player-card__pos{
+        background-color: $header-color1;
+        color: $bg-color1;
+        border-radius: 999px;
+        padding: 0 0.45rem;
+        font-weight: 700;
+        font-size: 0.8rem;
+    }
 }
 
 // Team list table — matches "Equipos Registrados" (list-teams).
@@ -302,11 +361,21 @@ th {
 // with spacing between the match info card and the logo.
 .scout-team-logo{
     margin-top: 1.5rem;
-    width: 27.5%;      // was col-3 (25%)
+    width: 30.25%;     // 10% larger than 27.5%
+    // Uniform square footprint for every team regardless of the source
+    // image's aspect ratio; `contain` keeps the whole logo visible (no crop).
+    aspect-ratio: 1 / 1;
+    object-fit: contain;
 
     @media (min-width: 768px){
-        width: 9.17%;  // was col-md-1 (~8.33%)
+        width: 10.09%; // 10% larger than 9.17%
     }
+}
+
+// In the Equipos tab the logo only has the back button above it (no match
+// card), so drop the extra top margin to bring it closer to the button.
+.team-roster--equipos .scout-team-logo{
+    margin-top: 0;
 }
 
 // Modern filter bar.

--- a/angular-app/src/app/restricted-area/scouting/scouting.component.ts
+++ b/angular-app/src/app/restricted-area/scouting/scouting.component.ts
@@ -190,6 +190,22 @@ export class ScoutingComponent implements OnInit {
     this.openPopup();
   }
 
+  async savePlayerNumber(number: string) {
+    if (!this.selectedPlayer?.id) return;
+    try {
+      await this.playerBuilder.updatePlayerNumber(this.ddb, this.selectedPlayer.id, number);
+      this.selectedPlayer.number = number;
+      // Keep the roster list in sync so the card badge reflects the new number.
+      const p = this.players.find(pl => pl.id == this.selectedPlayer!.id);
+      if (p) p.number = number;
+      this.submitReportMessage = "Número actualizado";
+    } catch (err) {
+      this.submitReportMessage = `Error guardando número. Contacta a Paco.\n${err}`;
+      console.error("Error updating player number", err);
+    }
+    this.openPopup();
+  }
+
   openPopup() {
     this.displayStyle = "block";
   }
@@ -383,7 +399,7 @@ export class ScoutingComponent implements OnInit {
       };
     } else {
       console.error("No data returned from downloadFile");
-      team.imageUrl = "assets/logo.png";
+      team.imageUrl = "assets/logo_gray.png";
     }
   }
 


### PR DESCRIPTION
- Add editable player number field with save button in both the Jugador tab evaluacion and the scouting player-card evaluation popup
- Add PlayerBuilder.updatePlayerNumber to persist the number to DynamoDB
- Default missing team logo to assets/logo_gray.png
- Enlarge team logo 10% and give it a uniform square footprint (aspect-ratio 1/1 + object-fit contain) so all logos look the same size
- Tighten spacing between the back button and logo in the Equipos tab