### PR TITLE
Improve coach team UI: navigation, logos, and modernized team view

### DIFF
--- a/angular-app/src/app/Builders/team-builder.ts
+++ b/angular-app/src/app/Builders/team-builder.ts
@@ -207,12 +207,12 @@ export class TeamBuilder {
         await ddb.updateItem(key, updateExpression, expressionAttributeNames, expressionAttributeValues);
     }
 
-    static getLogoFilePath(team: Team): string {
-        return `team-logos/${team.id}`;
+    static getLogoFilePath(teamId: string): string {
+        return `team-logos/${teamId}`;
     }
 
     async uploadTeamLogo(ddb: DynamoDb, s3: S3, team: Team, logoFile: Buffer | Uint8Array): Promise<void> {
-        let logoPath = TeamBuilder.getLogoFilePath(team);
+        let logoPath = TeamBuilder.getLogoFilePath(team.id);
         await s3.uploadFile(logoPath, logoFile, team.imageType!);
         await this.updateTeamLogoType(ddb, team.id, team.imageType!);
     }

--- a/angular-app/src/app/restricted-area/list-teams/list-teams.component.html
+++ b/angular-app/src/app/restricted-area/list-teams/list-teams.component.html
@@ -7,6 +7,12 @@
     <span class="sr-only">Loading...</span>
 </div>
 <div class="mainpanel" *ngIf="!loading">
+    <!-- Register a new team: sits above the list since it's the primary action. -->
+    <div class="d-flex justify-content-end mb-3" *ngIf="editable">
+        <button type="button" (click)="callParentToAddTeam()" class="btn btn-dark btn-floating" title="Registrar Nuevo Equipo" aria-label="Registrar Nuevo Equipo">
+            <i class="fas fa-plus"></i>
+        </button>
+    </div>
     <div class="scroll-container">
       <div style="min-width: 1000px;">
     <table class="row">
@@ -18,7 +24,7 @@
             <th class="col col-2 groupLast">Pago</th>
         </tr>
         <tr class="row" *ngFor="let team of teams" [routerLink]="" (click)="viewTeam(team.id)">
-            <td [ngClass]="{'col': true, 'col-3': userrole != 'coach', 'col-4': userrole === 'coach'}"><u>{{team.name}}</u></td>
+            <td [ngClass]="{'col': true, 'col-3': userrole != 'coach', 'col-4': userrole === 'coach'}"><img [src]="teamLogo(team.id)" class="team-list-logo"><u>{{team.name}}</u></td>
             <td class="col col-2">{{team.category}}</td>
             <td [ngClass]="{'col': true, 'col-3': userrole != 'coach', 'col-4': userrole === 'coach'}">{{team.location}}</td>
             <td *ngIf="userrole != 'coach'" class="col col-2">{{coaches.get(team.coachId)?.name}}</td>
@@ -32,10 +38,6 @@
     </table>
       </div>
       </div>
-    <br>
-    <div class="frow" >
-        <button *ngIf="editable" type="button" (click)="callParentToAddTeam()" class="btn btn-dark">Registrar Nuevo Equipo</button>
-    </div>
     <br>
     <div *ngIf="pastTeams.length>0">
         <h3 class="mb-3">

--- a/angular-app/src/app/restricted-area/list-teams/list-teams.component.scss
+++ b/angular-app/src/app/restricted-area/list-teams/list-teams.component.scss
@@ -28,3 +28,12 @@ th {
 .row{
     --bs-gutter-x: 0%;
 }
+
+// Small team logo shown before the team name in the list.
+.team-list-logo{
+    width: 1.5rem;
+    height: 1.5rem;
+    object-fit: contain;
+    vertical-align: middle;
+    margin-right: 0.5rem;
+}

--- a/angular-app/src/app/restricted-area/list-teams/list-teams.component.ts
+++ b/angular-app/src/app/restricted-area/list-teams/list-teams.component.ts
@@ -62,6 +62,8 @@ export class ListTeamsComponent {
     userrole = "";
     selectedRenewalTeam: Team | undefined
     renewalPlayers: Player[] | undefined
+    // Team logo URLs keyed by team id (falls back to the gray default logo).
+    teamLogos: Map<string, string | ArrayBuffer | null | undefined> = new Map();
 
     reloadLoginStatus() {
       this.userrole = this.authService.getUserRole();
@@ -125,10 +127,36 @@ export class ListTeamsComponent {
       this.teams = this.teams.filter(t => t.year === TOURNAMENT_YEAR)
       this.sortTeamsByCategory()
       let coachesList:Coach[] = await this.userBuilder.getCoaches(this.ddb);
-  
+
       coachesList.forEach(coach => {
         this.coaches.set(coach.id, coach);
       });
+
+      this.loadTeamLogos();
+    }
+
+    // Load each current team's logo from S3 into the teamLogos map so the list
+    // can show a small logo before the team name.
+    loadTeamLogos(){
+      this.teams.forEach(team => {
+        if (!this.teamLogos.has(team.id)) {
+          this.teamLogos.set(team.id, "assets/logo_gray.png");
+        }
+        if (team.imageType) {
+          this.s3.downloadFile(TeamBuilder.getLogoFilePath(team.id)).then(data => {
+            if (data) {
+              const blob = new Blob([data], { type: team.imageType });
+              const reader = new FileReader();
+              reader.readAsDataURL(blob);
+              reader.onload = () => this.teamLogos.set(team.id, reader.result);
+            }
+          });
+        }
+      });
+    }
+
+    teamLogo(teamId: string): string | ArrayBuffer | null | undefined {
+      return this.teamLogos.get(teamId) ?? "assets/logo_gray.png";
     }
 
     async ngOnInit() {

--- a/angular-app/src/app/restricted-area/restricted-area.component.html
+++ b/angular-app/src/app/restricted-area/restricted-area.component.html
@@ -22,12 +22,15 @@
                 </div>
 
                 <div *ngIf="registrationYear">
-                    <select #feature [value]="selectedFeature" (change)="changeFeature(feature.value)" *ngIf="menuItems.length > 0">
+                    <!-- Only show the navigation dropdown when there's more than
+                         one destination. Coaches have a single view (Equipos
+                         Registrados), so no dropdown is rendered for them. -->
+                    <select #feature [value]="selectedFeature" (change)="changeFeature(feature.value)" *ngIf="menuItems.length > 1">
                         <option *ngFor="let menuItem of menuItems" value="{{menuItem.value}}">{{menuItem.text}}</option>
                     </select>
-                    <br>
-                    <br>
-                    <br>
+                    <br *ngIf="menuItems.length > 1">
+                    <br *ngIf="menuItems.length > 1">
+                    <br *ngIf="menuItems.length > 1">
 
                     <div class="spinner-border text-light" role="status" *ngIf="loading">
                         <span class="sr-only">Loading...</span>

--- a/angular-app/src/app/restricted-area/restricted-area.component.ts
+++ b/angular-app/src/app/restricted-area/restricted-area.component.ts
@@ -151,9 +151,10 @@ export class RestrictedAreaComponent {
         ]);
       }
       if(this.isCoach){
+        // "Registrar Equipo" is reached via the "+" button in Equipos
+        // Registrados, so it's no longer a standalone menu entry.
         this.menuItems = this.menuItems.concat([
           {value: "listTeams", text: "Equipos Registrados"},
-          {value: "addTeam", text: "Registrar Equipo"},          
         ]);
       }
 

--- a/angular-app/src/app/restricted-area/scouting/scouting.component.html
+++ b/angular-app/src/app/restricted-area/scouting/scouting.component.html
@@ -202,7 +202,7 @@
                             <th class="col col-6">Categoria</th>
                         </tr>
                         <tr class="row" *ngFor="let team of filteredTeams" [routerLink]="" (click)="edit(team)">
-                            <td class="col col-6"><u>{{team.name}}</u></td>
+                            <td class="col col-6"><img [src]="teamLogo(team.id)" class="team-list-logo"><u>{{team.name}}</u></td>
                             <td class="col col-6">{{team.category}}</td>
                         </tr>
                     </table>

--- a/angular-app/src/app/restricted-area/scouting/scouting.component.scss
+++ b/angular-app/src/app/restricted-area/scouting/scouting.component.scss
@@ -125,6 +125,15 @@ th {
     --bs-gutter-x: 0%;
 }
 
+// Small team logo shown before the team name in the Equipos list.
+.team-list-logo{
+    width: 1.5rem;
+    height: 1.5rem;
+    object-fit: contain;
+    vertical-align: middle;
+    margin-right: 0.5rem;
+}
+
 .team-list-table tr{
     cursor: pointer;
 }

--- a/angular-app/src/app/restricted-area/scouting/scouting.component.ts
+++ b/angular-app/src/app/restricted-area/scouting/scouting.component.ts
@@ -41,6 +41,8 @@ export class ScoutingComponent implements OnInit {
   equipos : Team[] = [];
   filteredMatches: Match[] = [];
   filteredTeams: Team[] = [];
+  // Team logo URLs keyed by team id (falls back to the gray default logo).
+  teamLogos: Map<string, string | ArrayBuffer | null | undefined> = new Map();
 
   activeTab: 'partido' | 'jugador' | 'equipos' | 'estadisticas' = 'partido';
   isTeamSelected: boolean = false;
@@ -131,7 +133,32 @@ export class ScoutingComponent implements OnInit {
     this.filteredMatches = this.allMatches.sort((a, b) => (a.day! + a.time!).localeCompare(b.day! + b.time!));
     this.filteredTeams = this.equipos;
     this.applyCategoryFilter();
+    this.loadTeamLogos();
     this.loading = false;
+  }
+
+  // Load each team's logo from S3 into the teamLogos map so the Equipos list
+  // can show a small logo before the team name.
+  loadTeamLogos(){
+    this.equipos.forEach(team => {
+      if (!this.teamLogos.has(team.id)) {
+        this.teamLogos.set(team.id, "assets/logo_gray.png");
+      }
+      if (team.imageType) {
+        this.s3.downloadFile(TeamBuilder.getLogoFilePath(team.id)).then(data => {
+          if (data) {
+            const blob = new Blob([data], { type: team.imageType });
+            const reader = new FileReader();
+            reader.readAsDataURL(blob);
+            reader.onload = () => this.teamLogos.set(team.id, reader.result);
+          }
+        });
+      }
+    });
+  }
+
+  teamLogo(teamId: string): string | ArrayBuffer | null | undefined {
+    return this.teamLogos.get(teamId) ?? "assets/logo_gray.png";
   }
 
   applyCategoryFilter() {
@@ -386,11 +413,13 @@ export class ScoutingComponent implements OnInit {
   }
 
   async getTeamImgAsBuffer(team: MatchTeamWithPhoto){
-    let data = await this.s3.downloadFile(team.id)
+    // Team logos live under the team-logos/ prefix (same key as list-teams and
+    // view-teams), not images/{id}. Using the logo path also shares the S3 cache.
+    let data = await this.s3.downloadFile(TeamBuilder.getLogoFilePath(team.id))
     console.log("Downloaded data:", data);
 
     if (data) {
-      let blob = new Blob([data], { type: "image/jpeg" });
+      let blob = new Blob([data], { type: team.imageType ?? "image/jpeg" });
         // display blob as img
       const reader2 = new FileReader();
       reader2.readAsDataURL(blob);

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.html
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.html
@@ -29,43 +29,64 @@
         <i class="fa fa-trash"></i>
       </button>
     </h2>
-    <p *ngIf="paymentStatus === 'aprovado'" style="color: green;" class="text-center">Comprobante de pago aprovado</p>
-    <p *ngIf="paymentStatus === 'en_revision'" style="color: goldenrod;" class="text-center">Comprobante de pago en revisión</p>
-    <p *ngIf="paymentStatus === 'pendiente'" style="color: red;" class="text-center">Comprobante de pago pendiente</p>
+    <!-- Payment status + its upload action grouped together. -->
+    <div class="text-center mb-2">
+      <p *ngIf="paymentStatus === 'aprovado'" style="color: green;" class="mb-1">Comprobante de pago aprovado</p>
+      <p *ngIf="paymentStatus === 'en_revision'" style="color: goldenrod;" class="mb-1">Comprobante de pago en revisión</p>
+      <p *ngIf="paymentStatus === 'pendiente'" style="color: red;" class="mb-1">Comprobante de pago pendiente</p>
+      <button *ngIf="editable && paymentStatus !== 'aprovado'" type="button" (click)="openPaymentReceipt()" class="btn btn-dark btn-sm">
+        <i class="fa fa-upload"></i>&nbsp; Subir Comprobante de Pago
+      </button>
+    </div>
 
-    <table class="row">
-        <tr class="row" *ngIf="userrole!='coach'">
-            <th class="col col-lg-3 col-12"> <a [routerLink]="">Coach</a></th>
-            <td class="col col-lg-9 col-12"> <a [routerLink]="">{{team?.coachName}}</a></td>
-        </tr>
-        <tr class="row">
-            <th class="col col-lg-3 col-12"> <a [routerLink]="">Categoria</a></th>
-            <td class="col col-lg-9 col-12"> <a [routerLink]="">{{team?.category}}</a></td>
-        </tr>
-        <tr class="row">
-            <th class="col col-lg-3 col-12">Localidad</th>
-            <td class="col col-lg-9 col-12">{{team?.location}}</td>
-        </tr>
-    </table>
-    <p></p>
-    <button *ngIf="editable" type="button" (click)="selectCaptan()" class="btn btn-dark"> Seleccionar Capitán</button>&nbsp;
-    <button *ngIf="editable && paymentStatus !== 'aprovado'" type="button" (click)="openPaymentReceipt()" class="btn btn-dark"> Subir Comprobante de Pago</button>
-    <p></p>
+    <!-- Team attributes as a modern info card. -->
+    <div class="info-card">
+        <div class="info-item" *ngIf="userrole!='coach'">
+            <span class="info-label">Coach</span>
+            <span class="info-value">{{team?.coachName}}</span>
+        </div>
+        <div class="info-item">
+            <span class="info-label">Categoría</span>
+            <span class="info-value"><span class="badge-pill">{{team?.category}}</span></span>
+        </div>
+        <div class="info-item">
+            <span class="info-label">Localidad</span>
+            <span class="info-value">{{team?.location}}</span>
+        </div>
+    </div>
+    <!-- Roster actions grouped in one toolbar directly above the player list. -->
+    <div *ngIf="editable" class="d-flex flex-wrap gap-2 align-items-center justify-content-between mt-3 mb-2">
+      <h5 class="mb-0">Jugadores</h5>
+      <div class="d-flex flex-wrap gap-2">
+        <button type="button" (click)="selectCaptan()" class="btn btn-dark btn-sm">
+          <i class="fa fa-star"></i>&nbsp; Seleccionar Capitán
+        </button>
+        <button type="button" (click)="addPlayer()" class="btn btn-dark btn-sm">
+          <i class="fa fa-plus"></i>&nbsp; Nuevo Jugador
+        </button>
+        <button type="button" (click)="addExistingPlayer()" class="btn btn-dark btn-sm">
+          <i class="fa fa-user-plus"></i>&nbsp; Jugadores Existentes
+        </button>
+      </div>
+    </div>
     <div class="scroll-container">
       <div style="min-width: 400px;">
-        <table class="row">
+        <table class="row modern-table">
             <tr class="row">
-                <th class="col col-1"> <a [routerLink]="">#</a></th>
-                <th class="col col-6"> <a [routerLink]="">Jugador</a></th>
-                <th class="col col-3"> <a [routerLink]="">Posición</a></th>
-                <th class="col col-2"> <a [routerLink]=""></a></th>
+                <th class="col col-1">#</th>
+                <th class="col col-6">Jugador</th>
+                <th class="col col-3">Posición</th>
+                <th class="col col-2"></th>
             </tr>
-            <tr class="row" *ngFor="let player of players" [routerLink]="">
+            <tr class="row player-row" *ngFor="let player of players">
                 <td class="col col-1" (click)="editPlayer(player.id)">{{player.number}}</td>
-                <td class="col col-6" (click)="editPlayer(player.id)"><u>{{player.name}}{{(player.id === team?.captainId) ? " (Capitán)" : ""}}</u></td>
+                <td class="col col-6" (click)="editPlayer(player.id)">
+                    {{player.name}}
+                    <span *ngIf="player.id === team?.captainId" class="captain-badge"><i class="fa fa-star"></i> Capitán</span>
+                </td>
                 <td class="col col-3" (click)="editPlayer(player.id)">{{player.position}}</td>
-                <td class="col col-2">
-                  <button class="btn btn-outline-danger btn-floating m-1" title="Remover jugador" (click)="removePlayer(player.id)" target="_blank" role="button">
+                <td class="col col-2 text-end">
+                  <button class="btn btn-outline-danger btn-sm btn-floating" title="Remover jugador" (click)="removePlayer(player.id)" role="button">
                     <i class="fa fa-remove"></i>
                   </button>
                 </td>
@@ -73,12 +94,7 @@
         </table>
       </div>
     </div>
-    <br>
-    <button *ngIf="editable" type="button" (click)="addPlayer()" class="btn btn-dark"> Aggregar Nuevo Jugador</button>&nbsp;
-    <br>
-    <br>
-    <button *ngIf="editable" type="button" (click)="addExistingPlayer()" class="btn btn-dark"> Aggregar Jugadores Existentes</button>
-</div>  
+</div>
 
 <!--Edit team modal-->
 <div class="modal"

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.scss
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.scss
@@ -1,30 +1,111 @@
 @import "colors";
 
-table {
-    color: black;
-}
-
-td, th {
-    text-align: left;
-    border: 0px solid #dddddd;
-}
-
-td {
-    color: $text-color2;
-    background-color: $bg-color2;
-    padding: 8px;
-}
-
-tr{
-    border-bottom: 2px solid $header-color2;
-}
-
-th {
-    color: $text-color2;
-    background-color: $header-color2;
-    padding: 8px;
-}
-
 .row{
     --bs-gutter-x: 0%;
+}
+
+// Team attributes shown as a clean info card instead of a bordered table.
+.info-card{
+    background-color: $bg-color15;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 0.75rem;
+    padding: 0.5rem 1.25rem;
+    margin-bottom: 0.5rem;
+
+    .info-item{
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        padding: 0.6rem 0;
+
+        &:not(:last-child){
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        }
+    }
+
+    .info-label{
+        flex: 0 0 8rem;
+        color: $bg-color2;
+        opacity: 0.7;
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+    }
+
+    .info-value{
+        color: $bg-color2;
+        font-weight: 600;
+    }
+}
+
+// Small yellow capsule for short values like the category.
+.badge-pill{
+    display: inline-block;
+    background-color: $header-color1;
+    color: $bg-color1;
+    border-radius: 999px;
+    padding: 0.1rem 0.7rem;
+    font-weight: 700;
+    text-transform: capitalize;
+    font-size: 0.85rem;
+}
+
+// Modern roster table: rounded, borderless, hover-highlighted rows.
+.modern-table{
+    color: $bg-color1;
+    border-collapse: separate;
+    border-spacing: 0;
+
+    th{
+        text-align: left;
+        color: $bg-color1;
+        background-color: $header-color1;
+        padding: 0.6rem 0.75rem;
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+    }
+
+    td{
+        text-align: left;
+        color: $bg-color1;
+        background-color: $bg-color2;
+        padding: 0.6rem 0.75rem;
+        vertical-align: middle;
+    }
+
+    tr{
+        border-bottom: 1px solid rgba(72, 71, 71, 0.12);
+    }
+
+    // Rounded outer corners on the header and last row.
+    tr:first-child th:first-child{ border-top-left-radius: 0.6rem; }
+    tr:first-child th:last-child{ border-top-right-radius: 0.6rem; }
+    tr:last-child td:first-child{ border-bottom-left-radius: 0.6rem; }
+    tr:last-child td:last-child{ border-bottom-right-radius: 0.6rem; }
+
+    .player-row{
+        cursor: pointer;
+        transition: background-color 0.15s ease;
+
+        td{ transition: background-color 0.15s ease; }
+
+        &:hover td{
+            background-color: darken($bg-color2, 6%);
+        }
+    }
+}
+
+// Captain marker as a subtle pill next to the player name.
+.captain-badge{
+    display: inline-block;
+    margin-left: 0.4rem;
+    background-color: $header-color1;
+    color: $bg-color1;
+    border-radius: 999px;
+    padding: 0 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+
+    i{ font-size: 0.7rem; }
 }

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
@@ -138,7 +138,7 @@ export class ViewTeamsComponent {
     this.loading = false;
 
     if (this.team!.imageType){
-      await this.s3.downloadFile(TeamBuilder.getLogoFilePath(this.team!)).then((data) => {
+      await this.s3.downloadFile(TeamBuilder.getLogoFilePath(this.team!.id)).then((data) => {
         console.log("Downloaded data:", data);
         if (data) {
          let blob = new Blob([data], { type: this.team!.imageType });


### PR DESCRIPTION
- Simplify coach navigation to a single Equipos Registrados view; remove the redundant 'Registrar Equipo' dropdown entry and hide the dropdown when there's only one destination
- Move 'Registrar Nuevo Equipo' above the team list as a compact '+' icon
- Show a small team logo before the name in both team lists (Equipos Registrados and the Scouting Equipos tab), sharing the S3 cache
- Fix scouting team logo download to use the team-logos/ path (was images/), so the real logo loads and shares the cache; use the team's imageType
- Refactor TeamBuilder.getLogoFilePath to take a teamId string
- Regroup team-view action buttons by concern: payment upload beside the payment status, and the three roster actions in one toolbar above the list
- Modernize the team view: team attributes as a rounded info card and the roster as a modern hover-highlighted table with a captain pill badge, replacing the dated bordered tables and fake routerLink wrappers