### PR TITLE
Add liability waiver download to Equipos Registrados view

### DIFF
--- a/angular-app/package-lock.json
+++ b/angular-app/package-lock.json
@@ -36,7 +36,7 @@
         "jwt-decode": "^4.0.0",
         "mdb-angular-ui-kit": "^4.0.0",
         "mdb-ui-kit": "^6.2.0",
-        "ng": "^0.0.0",
+        "qrcode": "^1.5.4",
         "rxjs": "^7.8.0",
         "tslib": "^2.5.0",
         "zone.js": "^0.13.0"
@@ -47,6 +47,7 @@
         "@angular/compiler-cli": "^15.2.10",
         "@types/jasmine": "^4.3.1",
         "@types/node": "^18.16.0",
+        "@types/qrcode": "^1.5.6",
         "@types/uuid": "^9.0.1",
         "jasmine-core": "^4.6.0",
         "karma": "~6.3.0",
@@ -5122,6 +5123,16 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -6112,7 +6123,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -6827,6 +6837,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/default-gateway": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
@@ -6904,6 +6923,12 @@
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
       "integrity": "sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==",
       "dev": true
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -7570,7 +7595,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -9194,7 +9218,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -10036,11 +10059,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
-    "node_modules/ng": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/ng/-/ng-0.0.0.tgz",
-      "integrity": "sha512-HwR40IBJa1ZU+CIGyuy7vSCN3xFYlSRfw5eIwwKOdOMNNNIl8KhT6PXKmHuFEFYpfrbOMaCYtr4QOJ3gkkubcg=="
-    },
     "node_modules/nice-napi": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nice-napi/-/nice-napi-1.0.2.tgz",
@@ -10749,7 +10767,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -10764,7 +10781,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -10804,7 +10820,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -10952,7 +10967,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -11080,6 +11094,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -11323,6 +11346,122 @@
       "dev": true,
       "engines": {
         "node": ">=0.9"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -11605,6 +11744,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
@@ -12088,8 +12233,7 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -13514,6 +13658,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/wide-align": {
       "version": "1.1.5",

--- a/angular-app/package.json
+++ b/angular-app/package.json
@@ -38,6 +38,7 @@
     "jwt-decode": "^4.0.0",
     "mdb-angular-ui-kit": "^4.0.0",
     "mdb-ui-kit": "^6.2.0",
+    "qrcode": "^1.5.4",
     "rxjs": "^7.8.0",
     "tslib": "^2.5.0",
     "zone.js": "^0.13.0"
@@ -48,6 +49,7 @@
     "@angular/compiler-cli": "^15.2.10",
     "@types/jasmine": "^4.3.1",
     "@types/node": "^18.16.0",
+    "@types/qrcode": "^1.5.6",
     "@types/uuid": "^9.0.1",
     "jasmine-core": "^4.6.0",
     "karma": "~6.3.0",

--- a/angular-app/src/app/aws-clients/s3.ts
+++ b/angular-app/src/app/aws-clients/s3.ts
@@ -17,7 +17,17 @@ const REPORT_PATH = `${REPORT_DATA}/${TOURNAMENT_PREFIX}${TOURNAMENT_YEAR}`
 const IMAGE_PATH = "images"
 const LIABILITY_WAIVER_PATH = "liability-waiver"
 
-export { LIABILITY_WAIVER_PATH };
+// Blank liability-waiver template coaches hand out to players. Stored under
+// the liability-waiver path as `liability-waiver-<year>.pdf`, alongside the
+// per-player signed waivers.
+const LIABILITY_WAIVER_TEMPLATE_KEY = `${LIABILITY_WAIVER_PATH}/liability-waiver-${TOURNAMENT_YEAR}.pdf`
+
+// Public CloudFront distribution that exposes the blank waiver template at the
+// root, keyed only by year (e.g. `liability-waiver-2026.pdf`).
+const LIABILITY_WAIVER_CDN_DOMAIN = "https://d21i3xrq1b6i2p.cloudfront.net"
+const LIABILITY_WAIVER_TEMPLATE_CDN_URL = `${LIABILITY_WAIVER_CDN_DOMAIN}/liability-waiver-${TOURNAMENT_YEAR}.pdf`
+
+export { LIABILITY_WAIVER_PATH, LIABILITY_WAIVER_TEMPLATE_KEY };
 
 
 export enum ReportType {
@@ -234,6 +244,40 @@ export class S3 {
             console.error('Error downloading file:', err);
             return undefined;
         }
+    }
+
+    /**
+     * Download the blank liability-waiver template (bucket root, keyed by year).
+     * Returns the file bytes + content type, or undefined when the template
+     * for the current tournament year has not been uploaded yet.
+     */
+    async downloadLiabilityWaiverTemplate(): Promise<{data: Uint8Array, contentType: string} | undefined> {
+        const input: GetObjectCommandInput = {
+            Bucket: GLADIADORES_BUCKET_NAME,
+            Key: LIABILITY_WAIVER_TEMPLATE_KEY
+        };
+
+        try {
+            const response = await this.client.send(new GetObjectCommand(input));
+            const fileContent = await response.Body?.transformToByteArray();
+
+            if (fileContent) {
+                return {data: fileContent, contentType: response.ContentType ?? 'application/pdf'};
+            }
+
+            return undefined;
+        } catch (err) {
+            console.error('Error downloading liability waiver template:', err);
+            return undefined;
+        }
+    }
+
+    /**
+     * Public CloudFront URL for the blank liability-waiver template so a coach
+     * can share a permanent download link (keyed by year).
+     */
+    getLiabilityWaiverTemplateUrl(): string {
+        return LIABILITY_WAIVER_TEMPLATE_CDN_URL;
     }
 
     static async build(credentials: AwsCredentialIdentity | Provider<AwsCredentialIdentity>): Promise<S3> {

--- a/angular-app/src/app/restricted-area/list-teams/list-teams.component.html
+++ b/angular-app/src/app/restricted-area/list-teams/list-teams.component.html
@@ -7,9 +7,13 @@
     <span class="sr-only">Loading...</span>
 </div>
 <div class="mainpanel" *ngIf="!loading">
-    <!-- Register a new team: sits above the list since it's the primary action. -->
-    <div class="d-flex justify-content-end mb-3" *ngIf="editable">
-        <button type="button" (click)="callParentToAddTeam()" class="btn btn-dark btn-floating" title="Registrar Nuevo Equipo" aria-label="Registrar Nuevo Equipo">
+    <!-- Top actions: download the shared liability waiver (same for all teams)
+         and register a new team (primary action). -->
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+        <button type="button" (click)="openWaiverTemplate()" class="btn btn-dark btn-sm">
+            <i class="fas fa-file-arrow-down"></i>&nbsp; Descargar Carta Responsiva
+        </button>
+        <button *ngIf="editable" type="button" (click)="callParentToAddTeam()" class="btn btn-dark btn-floating" title="Registrar Nuevo Equipo" aria-label="Registrar Nuevo Equipo">
             <i class="fas fa-plus"></i>
         </button>
     </div>
@@ -107,6 +111,46 @@
                 (click)="closeErrorPopup()">
           Cerrar
         </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!--Liability waiver template distribution modal-->
+<div class="modal"
+      tabindex="-1"
+      role="dialog"
+      [ngStyle]="{'display':displayWaiverTemplate}">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header dark-header">
+        <h5 class="modal-title">Carta Responsiva {{year}}</h5>
+        <button type="button" class="btn-close" (click)="closeWaiverTemplate()" aria-label="Close">
+        </button>
+      </div>
+      <div class="modal-body text-center">
+        <div *ngIf="loadingWaiverTemplate" class="text-center">
+          <div class="spinner-border text-dark" role="status">
+            <span class="sr-only">Loading...</span>
+          </div>
+        </div>
+
+        <p *ngIf="waiverTemplateError" style="color: red;">{{waiverTemplateError}}</p>
+
+        <div *ngIf="!loadingWaiverTemplate && waiverTemplateShareUrl">
+          <p class="mb-2">Descarga la carta responsiva o comparte este enlace o código QR con tus jugadores:</p>
+
+          <img *ngIf="waiverTemplateQrUrl" [src]="waiverTemplateQrUrl" alt="Código QR Carta Responsiva" class="mb-2" style="max-width: 240px;">
+
+          <div class="d-flex flex-wrap gap-2 justify-content-center">
+            <button type="button" (click)="downloadWaiverTemplate()" class="btn btn-dark btn-sm">
+              <i class="fa fa-download"></i>&nbsp; Descargar
+            </button>
+            <button type="button" (click)="copyWaiverLink()" class="btn btn-dark btn-sm">
+              <i class="fa fa-link"></i>&nbsp; {{ copiedWaiverLink ? 'Enlace copiado' : 'Copiar enlace' }}
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/angular-app/src/app/restricted-area/list-teams/list-teams.component.html
+++ b/angular-app/src/app/restricted-area/list-teams/list-teams.component.html
@@ -131,7 +131,7 @@
       <div class="modal-body text-center">
         <div *ngIf="loadingWaiverTemplate" class="text-center">
           <div class="spinner-border text-dark" role="status">
-            <span class="sr-only">Loading...</span>
+            <span class="sr-only">Cargando...</span>
           </div>
         </div>
 

--- a/angular-app/src/app/restricted-area/list-teams/list-teams.component.ts
+++ b/angular-app/src/app/restricted-area/list-teams/list-teams.component.ts
@@ -270,7 +270,7 @@ export class ListTeamsComponent {
 
       const result = await this.s3.downloadLiabilityWaiverTemplate();
       if (!result) {
-        this.waiverTemplateError = "Carta responsiva no esta disponible todavia intente mas tarde";
+        this.waiverTemplateError = "Carta responsiva no esta disponible todavia. Intente mas tarde";
         this.loadingWaiverTemplate = false;
         return;
       }

--- a/angular-app/src/app/restricted-area/list-teams/list-teams.component.ts
+++ b/angular-app/src/app/restricted-area/list-teams/list-teams.component.ts
@@ -12,6 +12,7 @@ import { PlayerBuilder } from 'src/app/Builders/player-builder';
 import { FormArray, FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { FeatureFlag } from 'src/app/interfaces/feature-flag';
 import { FeatureFlagBuilder } from 'src/app/Builders/feature-flag-builder';
+import * as QRCode from 'qrcode';
 
 @Component({
   selector: 'app-list-teams',
@@ -64,6 +65,16 @@ export class ListTeamsComponent {
     renewalPlayers: Player[] | undefined
     // Team logo URLs keyed by team id (falls back to the gray default logo).
     teamLogos: Map<string, string | ArrayBuffer | null | undefined> = new Map();
+
+    // Blank liability-waiver template distribution (download + link + QR code).
+    // The waiver is the same for every team, so it lives on the teams list.
+    displayWaiverTemplate = "none";
+    loadingWaiverTemplate = false;
+    waiverTemplateError = "";
+    waiverTemplateShareUrl: string | undefined;
+    waiverTemplateQrUrl: string | undefined;
+    waiverTemplateFile: {data: Uint8Array, contentType: string} | undefined;
+    copiedWaiverLink = false;
 
     reloadLoginStatus() {
       this.userrole = this.authService.getUserRole();
@@ -239,6 +250,71 @@ export class ListTeamsComponent {
         await this.teamBuilder.updatePaymentStatus(this.ddb, this.reviewTeam.id, PaymentStatus.APPROVED);
         this.reviewTeam.paymentStatus = PaymentStatus.APPROVED;
         this.closePaymentReview();
+      }
+    }
+
+    /**
+     * Open the liability-waiver distribution modal: verify this year's blank
+     * template is available and build a shareable public link + QR code. The
+     * file is NOT downloaded automatically — the coach downloads it via the
+     * "Descargar" button. Shows an unavailable message when it's missing.
+     */
+    async openWaiverTemplate(){
+      this.waiverTemplateError = "";
+      this.waiverTemplateShareUrl = undefined;
+      this.waiverTemplateQrUrl = undefined;
+      this.waiverTemplateFile = undefined;
+      this.copiedWaiverLink = false;
+      this.loadingWaiverTemplate = true;
+      this.displayWaiverTemplate = "block";
+
+      const result = await this.s3.downloadLiabilityWaiverTemplate();
+      if (!result) {
+        this.waiverTemplateError = "Carta responsiva no esta disponible todavia intente mas tarde";
+        this.loadingWaiverTemplate = false;
+        return;
+      }
+
+      // Keep the bytes so the download only happens when the coach clicks.
+      this.waiverTemplateFile = result;
+
+      // Public link + QR code so coaches can distribute the template.
+      const shareUrl = this.s3.getLiabilityWaiverTemplateUrl();
+      this.waiverTemplateShareUrl = shareUrl;
+      try {
+        this.waiverTemplateQrUrl = await QRCode.toDataURL(shareUrl, {width: 240, margin: 1});
+      } catch (err) {
+        console.error('Error generating QR code for waiver template:', err);
+      }
+
+      this.loadingWaiverTemplate = false;
+    }
+
+    downloadWaiverTemplate(){
+      if (!this.waiverTemplateFile) return;
+
+      const blob = new Blob([this.waiverTemplateFile.data as any], {type: this.waiverTemplateFile.contentType});
+      const objectUrl = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = objectUrl;
+      link.download = `carta-responsiva-${this.year}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(objectUrl);
+    }
+
+    closeWaiverTemplate(){
+      this.displayWaiverTemplate = "none";
+    }
+
+    async copyWaiverLink(){
+      if (!this.waiverTemplateShareUrl) return;
+      try {
+        await navigator.clipboard.writeText(this.waiverTemplateShareUrl);
+        this.copiedWaiverLink = true;
+      } catch (err) {
+        console.error('Error copying waiver link:', err);
       }
     }
 


### PR DESCRIPTION
Coaches can download the shared blank liability-waiver template and distribute it via a public CloudFront link + QR code. The waiver is the same for all teams, so the action lives on the teams list above the list.

- S3: fetch template (liability-waiver/liability-waiver-<year>.pdf) and build the public CloudFront share URL (keyed dynamically by year)
- Manual download on button click; shows unavailable message if missing
- Add qrcode dependency for the shareable QR code