### PR TITLE
Clarify team logo upload and simplify team-edit view

### DIFF
--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.html
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.html
@@ -9,18 +9,6 @@
   </button>
   
     <h2 class="text-center mb-3">
-      <div class="row">
-        <div class="col col-12 col-lg-5" style="position: relative; z-index: 1; display: block; width: 200px; margin-left: auto; margin-right: auto; height: 200px;">
-          <div *ngIf="loadingImage" class="text-center" style="position: absolute;top: 0;left: 1%;z-index: 2;">
-            <div class="spinner-border text-dark" role="status">
-              <span class="sr-only">Loading...</span>
-            </div>
-          </div>
-          <img id="image" style="max-height: 200px; max-width:90%;position: absolute; top:0; left:0; ;z-index: 1;" [src]="teamLogoUrl">
-          <label *ngIf="!loadingImage" style="position: absolute;top: 0;left: 1%;z-index: 2;" for="photoFile"><i class="fa fa-camera" style="font-size: 1em;"></i></label>
-          <input *ngIf="!loadingImage" style="display:none;" id="photoFile" type="file" (change)="onLogoSelected($event)" accept="image/*" maxFileSize="10000000">
-        </div>
-      </div>
       {{team?.name}} &nbsp;
       <button class="btn btn-outline-danger btn-sm" *ngIf="editable" title="Editar Equipo" (click)="openEditTeam()" target="_blank" role="button">
         <i class="fa fa-pencil"></i>
@@ -29,6 +17,27 @@
         <i class="fa fa-trash"></i>
       </button>
     </h2>
+
+    <!-- Team logo upload. The label sits above an empty slot as a prompt; once a
+         logo exists it moves below as a caption and the helper text is hidden. -->
+    <div class="team-logo-upload">
+      <span *ngIf="!hasLogo" class="team-logo-upload__label">Logo del Equipo</span>
+      <div class="team-logo-upload__frame" [class.team-logo-upload__frame--filled]="hasLogo">
+        <div *ngIf="loadingImage" class="team-logo-upload__spinner">
+          <div class="spinner-border text-dark" role="status">
+            <span class="sr-only">Loading...</span>
+          </div>
+        </div>
+        <img class="team-logo-upload__img" [src]="teamLogoUrl" alt="Logo del equipo">
+        <label *ngIf="!loadingImage && editable" class="team-logo-upload__camera" for="photoFile"
+               title="Subir logo del equipo" aria-label="Subir logo del equipo">
+          <i class="fa fa-camera"></i>
+        </label>
+        <input *ngIf="!loadingImage" style="display:none;" id="photoFile" type="file" (change)="onLogoSelected($event)" accept="image/*" maxFileSize="10000000">
+      </div>
+      <span *ngIf="hasLogo" class="team-logo-upload__label">Logo del Equipo</span>
+      <span *ngIf="editable && !hasLogo" class="team-logo-upload__hint">Sube el logo o escudo de tu equipo.</span>
+    </div>
     <!-- Payment status + its upload action grouped together. -->
     <div class="text-center mb-2">
       <p *ngIf="paymentStatus === 'aprovado'" style="color: green;" class="mb-1">Comprobante de pago aprovado</p>
@@ -148,11 +157,7 @@
         <span style="background-color: red">{{errorMsg}}</span>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-danger" 
-                (click)="deletePlayer()">
-          Eliminar Jugador
-        </button>
-        <button type="button" class="btn btn-danger" 
+        <button type="button" class="btn btn-danger"
                 (click)="confirmEditTeam()">
           Confirmar
         </button>

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.scss
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.scss
@@ -4,6 +4,82 @@
     --bs-gutter-x: 0%;
 }
 
+// Team logo upload slot: a shield/crest-shaped frame with a label and helper
+// text, so coaches see clearly that this is the team logo (not a personal photo).
+.team-logo-upload{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0 auto 1rem;
+    max-width: 260px;
+
+    &__label{
+        color: $bg-color2;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        font-size: 0.8rem;
+        font-weight: 700;
+    }
+
+    &__frame{
+        position: relative;
+        width: 200px;
+        height: 200px;
+        border-radius: 0.75rem;
+        background-color: $bg-color15;
+        border: 2px dashed rgba(255, 255, 255, 0.35);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        // Once a real logo is uploaded, drop the empty-slot styling.
+        &--filled{
+            background-color: transparent;
+            border: none;
+        }
+    }
+
+    &__img{
+        max-width: 90%;
+        max-height: 90%;
+        object-fit: contain;
+    }
+
+    &__spinner{
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        z-index: 2;
+    }
+
+    &__camera{
+        position: absolute;
+        bottom: 0.4rem;
+        right: 0.4rem;
+        z-index: 2;
+        background-color: $header-color1;
+        color: $bg-color1;
+        width: 2rem;
+        height: 2rem;
+        border-radius: 999px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+    }
+
+    &__hint{
+        color: $bg-color2;
+        opacity: 0.75;
+        font-size: 0.75rem;
+        text-align: center;
+        max-width: 240px;
+    }
+}
+
 // Team attributes shown as a clean info card instead of a bordered table.
 .info-card{
     background-color: $bg-color15;

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
@@ -73,6 +73,11 @@ export class ViewTeamsComponent {
   selectedCaptain:string = "";
   teamLogoUrl: string | ArrayBuffer | null | undefined = "assets/logo_gray.png";
 
+  // True once a real logo has been uploaded (i.e. not the gray placeholder).
+  get hasLogo(): boolean {
+    return !!this.teamLogoUrl && this.teamLogoUrl !== "assets/logo_gray.png";
+  }
+
 
   receiptFiles: {data: Buffer, contentType: string, preview: string}[] = [];
   existingReceiptUrls: string[] = [];


### PR DESCRIPTION
- Add a labeled logo upload slot with helper text and a descriptive tooltip so coaches know it's the team logo, not a personal photo
- Move team name above the logo; label sits below once a logo exists
- Drop the empty-slot dashed frame/background once a logo is uploaded
- Remove the Eliminar Jugador button from the team editing modal