### PR TITLE
Fix stale waiver upload and show waiver status in player tables

### DIFF
--- a/angular-app/src/app/Builders/player-builder.ts
+++ b/angular-app/src/app/Builders/player-builder.ts
@@ -48,6 +48,26 @@ export class PlayerBuilder {
         return `liability-waiver-${playerId}`;
     }
 
+    // Fetch a player's signed waiver from S3 as an object URL so it can be shown
+    // in a viewer. Shared by the player tables so both behave identically.
+    // Returns undefined when there is no waiver or it cannot be fetched.
+    async loadLiabilityWaiver(s3: S3, player: Player): Promise<{url: string, isPdf: boolean} | undefined> {
+        if (!player.liabilityWaiver) {
+            return undefined;
+        }
+
+        const result = await s3.downloadFileWithType(player.liabilityWaiver, LIABILITY_WAIVER_PATH);
+        if (!result) {
+            return undefined;
+        }
+
+        const blob = new Blob([result.data as BlobPart], {type: result.contentType});
+        return {
+            url: URL.createObjectURL(blob),
+            isPdf: result.contentType === 'application/pdf'
+        };
+    }
+
     async uploadLiabilityWaiver(ddb: DynamoDb, s3: S3, playerId: string, data: Buffer | Uint8Array, contentType: string): Promise<void> {
         const fileName = PlayerBuilder.getLiabilityWaiverFileName(playerId);
         await s3.uploadFile(fileName, data, contentType, LIABILITY_WAIVER_PATH);

--- a/angular-app/src/app/restricted-area/list-players/list-players.component.html
+++ b/angular-app/src/app/restricted-area/list-players/list-players.component.html
@@ -91,27 +91,27 @@
     </form>
 
     <div class="scroll-container">
-        <div style="min-width: 600px;">
+        <div style="min-width: 750px;">
             <table class="row modern-table">
                 <tr class="row">
                     <th class="col col-1">#</th>
                     <th class="col col-3"> <a [routerLink]="" (click)="sortBy('name')">Jugador{{sortIndicator('name')}}</a></th>
                     <th class="col col-2"> <a [routerLink]="" (click)="sortBy('team')">Equipo{{sortIndicator('team')}}</a></th>
                     <th class="col col-2"> <a [routerLink]="" (click)="sortBy('category')">Categoria{{sortIndicator('category')}}</a></th>
-                    <th class="col col-1"> <a [routerLink]="" (click)="sortBy('height')">Altura{{sortIndicator('height')}}</a></th>
+                    <th class="col col-2"> <a [routerLink]="" (click)="sortBy('height')">Altura{{sortIndicator('height')}}</a></th>
                     <th class="col col-1"> <a [routerLink]="" (click)="sortBy('weight')">Peso{{sortIndicator('weight')}}</a></th>
-                    <th class="col col-2"> <a [routerLink]="" (click)="sortBy('waiver')">Carta{{sortIndicator('waiver')}}</a></th>
+                    <th class="col col-1"> <a [routerLink]="" (click)="sortBy('waiver')">Carta{{sortIndicator('waiver')}}</a></th>
                 </tr>
                 <tr class="row clickable-row" *ngFor="let player of filteredPlayers" [routerLink]="" (click)="showPlayer(player)" >
                     <td class="col col-1">{{player.number}}</td>
                     <td class="col col-3">{{player.name}}</td>
                     <td class="col col-2">{{uTeams.get(player.team)}}</td>
                     <td class="col col-2">{{player.category}}</td>
-                    <td class="col col-1">{{player.height}}</td>
+                    <td class="col col-2">{{player.height}}</td>
                     <td class="col col-1">{{player.weight}}</td>
                     <!-- Waiver availability; click the icon to view it. Nothing is
                          shown when no waiver has been uploaded. -->
-                    <td class="col col-2">
+                    <td class="col col-1">
                         <a *ngIf="player.liabilityWaiver" class="waiver-link" [routerLink]="" title="Ver carta responsiva"
                            (click)="viewWaiver(player, $event)">
                             <i class="fas fa-file-lines"></i>

--- a/angular-app/src/app/restricted-area/list-players/list-players.component.html
+++ b/angular-app/src/app/restricted-area/list-players/list-players.component.html
@@ -98,16 +98,25 @@
                     <th class="col col-3"> <a [routerLink]="" (click)="sortBy('name')">Jugador{{sortIndicator('name')}}</a></th>
                     <th class="col col-2"> <a [routerLink]="" (click)="sortBy('team')">Equipo{{sortIndicator('team')}}</a></th>
                     <th class="col col-2"> <a [routerLink]="" (click)="sortBy('category')">Categoria{{sortIndicator('category')}}</a></th>
-                    <th class="col col-2"> <a [routerLink]="" (click)="sortBy('height')">Altura{{sortIndicator('height')}}</a></th>
-                    <th class="col col-2"> <a [routerLink]="" (click)="sortBy('weight')">Peso{{sortIndicator('weight')}}</a></th>
+                    <th class="col col-1"> <a [routerLink]="" (click)="sortBy('height')">Altura{{sortIndicator('height')}}</a></th>
+                    <th class="col col-1"> <a [routerLink]="" (click)="sortBy('weight')">Peso{{sortIndicator('weight')}}</a></th>
+                    <th class="col col-2"> <a [routerLink]="" (click)="sortBy('waiver')">Carta{{sortIndicator('waiver')}}</a></th>
                 </tr>
                 <tr class="row clickable-row" *ngFor="let player of filteredPlayers" [routerLink]="" (click)="showPlayer(player)" >
                     <td class="col col-1">{{player.number}}</td>
                     <td class="col col-3">{{player.name}}</td>
                     <td class="col col-2">{{uTeams.get(player.team)}}</td>
                     <td class="col col-2">{{player.category}}</td>
-                    <td class="col col-2">{{player.height}}</td>
-                    <td class="col col-2">{{player.weight}}</td>
+                    <td class="col col-1">{{player.height}}</td>
+                    <td class="col col-1">{{player.weight}}</td>
+                    <!-- Waiver availability; click the icon to view it. Nothing is
+                         shown when no waiver has been uploaded. -->
+                    <td class="col col-2">
+                        <a *ngIf="player.liabilityWaiver" class="waiver-link" [routerLink]="" title="Ver carta responsiva"
+                           (click)="viewWaiver(player, $event)">
+                            <i class="fas fa-file-lines"></i>
+                        </a>
+                    </td>
                 </tr>
             </table>
         </div>
@@ -139,6 +148,34 @@
                     (click)="confirmEditPlayer()">
               Confirmar
             </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!--Liability waiver viewer modal-->
+    <div class="modal"
+          tabindex="-1"
+          role="dialog"
+          [ngStyle]="{'display':displayWaiver}">
+      <div class="modal-dialog modal-fullscreen" role="document">
+        <div class="modal-content">
+          <div class="modal-header dark-header">
+            <h5 class="modal-title">Carta Responsiva - {{waiverPlayerName}}</h5>
+            <button type="button" class="btn-close" (click)="closeWaiver()" aria-label="Close">
+            </button>
+          </div>
+          <div class="modal-body" style="height: 100%;">
+            <div *ngIf="loadingWaiver" class="text-center">
+              <div class="spinner-border text-dark" role="status">
+                <span class="sr-only">Loading...</span>
+              </div>
+            </div>
+            <p *ngIf="waiverError" style="color: red;">{{waiverError}}</p>
+            <iframe *ngIf="!loadingWaiver && waiverSafeUrl && waiverIsPdf" [src]="waiverSafeUrl" style="width: 100%; height: 100%; border: none;"></iframe>
+            <div *ngIf="!loadingWaiver && waiverUrl && !waiverIsPdf" class="text-center" style="height: 100%; overflow: auto;">
+              <img [src]="waiverUrl" alt="Carta Responsiva" style="max-width: 100%;">
+            </div>
           </div>
         </div>
       </div>

--- a/angular-app/src/app/restricted-area/list-players/list-players.component.ts
+++ b/angular-app/src/app/restricted-area/list-players/list-players.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, ViewChild } from '@angular/core';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { AuthService } from '../../auth.service';
 import { DynamoDb } from '../../aws-clients/dynamodb';
 import { TeamBuilder } from '../../Builders/team-builder';
@@ -22,7 +23,8 @@ export class ListPlayersComponent {
         private authService: AuthService,
         private teamBuilder: TeamBuilder,
         private userBuilder: UserBuilder,
-        private playerBuilder: PlayerBuilder
+        private playerBuilder: PlayerBuilder,
+        private sanitizer: DomSanitizer
       ){}
 
 
@@ -133,6 +135,12 @@ export class ListPlayersComponent {
           if (bEmpty) return this.sortAsc ? -1 : 1;
           return va - vb;
         }
+        case 'waiver': {
+          // Players with a waiver first when ascending.
+          const wa = a.liabilityWaiver ? 0 : 1;
+          const wb = b.liabilityWaiver ? 0 : 1;
+          return wa - wb;
+        }
         default:
           return 0;
       }
@@ -238,6 +246,44 @@ export class ListPlayersComponent {
       // whose ngOnInit loads this player's details from its bound inputs.
       this.player = player
       this.displayPlayer = "block"
+    }
+
+    // Waiver viewer shown from the table's "Carta" column.
+    displayWaiver = "none";
+    loadingWaiver = false;
+    waiverUrl: string | undefined;
+    waiverSafeUrl: SafeResourceUrl | undefined;
+    waiverIsPdf = false;
+    waiverError = "";
+    waiverPlayerName = "";
+
+    // Show a player's signed waiver in a modal. Stops the click from also
+    // opening the player editor, since the whole row is clickable.
+    async viewWaiver(player: Player, event: Event){
+      event.stopPropagation();
+
+      this.waiverUrl = undefined;
+      this.waiverSafeUrl = undefined;
+      this.waiverError = "";
+      this.waiverPlayerName = player.name;
+      this.loadingWaiver = true;
+      this.displayWaiver = "block";
+
+      const result = await this.playerBuilder.loadLiabilityWaiver(this.s3, player);
+      if (result) {
+        this.waiverIsPdf = result.isPdf;
+        this.waiverUrl = result.url;
+        this.waiverSafeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(result.url);
+      } else {
+        this.waiverError = "No se pudo cargar la carta responsiva.";
+      }
+      this.loadingWaiver = false;
+    }
+
+    closeWaiver(){
+      this.displayWaiver = "none";
+      this.waiverUrl = undefined;
+      this.waiverSafeUrl = undefined;
     }
 
     async confirmEditPlayer(){

--- a/angular-app/src/app/restricted-area/view-teams/add-player/add-player.component.html
+++ b/angular-app/src/app/restricted-area/view-teams/add-player/add-player.component.html
@@ -3,7 +3,7 @@
     <div class="col col-12 col-lg-5" style="position: relative;z-index: 1; height:200px">
       <img id="image" style="max-height: 200px; max-width:90%;position: absolute; top:0; left:0; ;z-index: 1;" [src]="imageUrl">
       <label *ngIf="this.player.id" style="position: absolute;top: 0;left: 0;z-index: 2;" for="playerPhotoFile"><i class="fa fa-camera" style="font-size: 2em;"></i></label>
-      <input *ngIf="this.player.id" style="display:none;" id="playerPhotoFile" type="file" (change)="onFileSelected($event)" accept="image/*" maxFileSize="10000000">
+      <input #photoInput *ngIf="this.player.id" style="display:none;" id="playerPhotoFile" type="file" (change)="onFileSelected($event)" accept="image/*" maxFileSize="10000000">
     </div>
     <div class="col col-12 col-lg-7">
       <input name="scout" type="text" formControlName="equipo" value="{{player.team}}" hidden readonly required>
@@ -33,7 +33,7 @@
 
       <label class="frow" for="waiverFile">Carta Responsiva:&nbsp;</label>
       <div class="frow">
-        <input id="waiverFile" type="file" (change)="onWaiverSelected($event)" accept="image/*,application/pdf">
+        <input #waiverInput id="waiverFile" type="file" (change)="onWaiverSelected($event)" accept="image/*,application/pdf">
       </div>
       <p *ngIf="waiverError" style="color: red;">{{waiverError}}</p>
       <div class="frow" *ngIf="player.liabilityWaiver">

--- a/angular-app/src/app/restricted-area/view-teams/add-player/add-player.component.ts
+++ b/angular-app/src/app/restricted-area/view-teams/add-player/add-player.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, ElementRef, Input, ViewChild } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { FormBuilder, Validators } from '@angular/forms';
 import { AuthService } from '../../../auth.service';
@@ -68,13 +68,21 @@ export class AddPlayerComponent {
   waiverSafeUrl: SafeResourceUrl | undefined;
   waiverIsPdf = false;
 
+  // The parent only hides this component's modal (it is never destroyed), so
+  // the file inputs must be cleared by hand when switching players.
+  @ViewChild('photoInput') photoInput?: ElementRef<HTMLInputElement>;
+  @ViewChild('waiverInput') waiverInput?: ElementRef<HTMLInputElement>;
+
   async ngOnInit() {
-    this.imgToUpload = undefined
     this.loadPlayer(this.playerId);
   }
 
 
   async loadPlayer(playerId: string){
+    // Drop any file picked for the previously opened player, otherwise it would
+    // be uploaded under this player's id on "Confirmar".
+    this.clearPendingUploads();
+
     let existingPlayer = this.teamplayers.find(p => p.id === playerId)
     if (existingPlayer){
       this.player = existingPlayer;
@@ -120,6 +128,22 @@ export class AddPlayerComponent {
 
   }
 
+
+  // Reset every piece of pending upload state (buffers, errors, previews and the
+  // native file inputs) so nothing leaks from one player to the next.
+  clearPendingUploads(){
+    this.imgToUpload = undefined;
+    this.waiverToUpload = undefined;
+    this.waiverError = "";
+    this.blob = undefined;
+    this.closeLiabilityWaiver();
+    if (this.photoInput) {
+      this.photoInput.nativeElement.value = "";
+    }
+    if (this.waiverInput) {
+      this.waiverInput.nativeElement.value = "";
+    }
+  }
 
   togglePosition(position: string): void {
     this.selectedPositions[position] = !this.selectedPositions[position];

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.html
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.html
@@ -83,17 +83,26 @@
         <table class="row modern-table">
             <tr class="row">
                 <th class="col col-1">#</th>
-                <th class="col col-6">Jugador</th>
+                <th class="col col-4">Jugador</th>
                 <th class="col col-3">Posición</th>
+                <th class="col col-2">Carta</th>
                 <th class="col col-2"></th>
             </tr>
             <tr class="row clickable-row" *ngFor="let player of players">
                 <td class="col col-1" (click)="editPlayer(player.id)">{{player.number}}</td>
-                <td class="col col-6" (click)="editPlayer(player.id)">
+                <td class="col col-4" (click)="editPlayer(player.id)">
                     {{player.name}}
                     <span *ngIf="player.id === team?.captainId" class="captain-badge"><i class="fa fa-star"></i> Capitán</span>
                 </td>
                 <td class="col col-3" (click)="editPlayer(player.id)">{{player.position}}</td>
+                <!-- Waiver availability; click the icon to view it. Nothing is
+                     shown when no waiver has been uploaded. -->
+                <td class="col col-2">
+                    <a *ngIf="player.liabilityWaiver" class="waiver-link" [routerLink]="" title="Ver carta responsiva"
+                       (click)="viewWaiver(player, $event)">
+                        <i class="fas fa-file-lines"></i>
+                    </a>
+                </td>
                 <td class="col col-2 text-end">
                   <button class="btn btn-outline-danger btn-sm btn-floating" title="Remover jugador" (click)="removePlayer(player.id)" role="button">
                     <i class="fa fa-remove"></i>
@@ -368,10 +377,38 @@
         <app-add-player [teamplayers]="players" [equipoId]="team?.id!" [categoria]="team?.category!" [playerId]="newplayerid" [ddb]="ddb" [s3]="s3"></app-add-player>
       </div>
       <div class="modal-footer">
-        <button *ngIf="editable" type="button" class="btn btn-danger" 
+        <button *ngIf="editable" type="button" class="btn btn-danger"
                 (click)="confirmAddPlayer()">
           Confirmar
         </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!--Liability waiver viewer modal-->
+<div class="modal"
+      tabindex="-1"
+      role="dialog"
+      [ngStyle]="{'display':displayWaiver}">
+  <div class="modal-dialog modal-fullscreen" role="document">
+    <div class="modal-content">
+      <div class="modal-header dark-header">
+        <h5 class="modal-title">Carta Responsiva - {{waiverPlayerName}}</h5>
+        <button type="button" class="btn-close" (click)="closeWaiver()" aria-label="Close">
+        </button>
+      </div>
+      <div class="modal-body" style="height: 100%;">
+        <div *ngIf="loadingWaiver" class="text-center">
+          <div class="spinner-border text-dark" role="status">
+            <span class="sr-only">Loading...</span>
+          </div>
+        </div>
+        <p *ngIf="waiverError" style="color: red;">{{waiverError}}</p>
+        <iframe *ngIf="!loadingWaiver && waiverSafeUrl && waiverIsPdf" [src]="waiverSafeUrl" style="width: 100%; height: 100%; border: none;"></iframe>
+        <div *ngIf="!loadingWaiver && waiverUrl && !waiverIsPdf" class="text-center" style="height: 100%; overflow: auto;">
+          <img [src]="waiverUrl" alt="Carta Responsiva" style="max-width: 100%;">
+        </div>
       </div>
     </div>
   </div>

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.html
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.html
@@ -79,31 +79,31 @@
       </div>
     </div>
     <div class="scroll-container">
-      <div style="min-width: 400px;">
+      <div style="min-width: 750px;">
         <table class="row modern-table">
             <tr class="row">
                 <th class="col col-1">#</th>
-                <th class="col col-4">Jugador</th>
+                <th class="col col-6">Jugador</th>
                 <th class="col col-3">Posición</th>
-                <th class="col col-2">Carta</th>
-                <th class="col col-2"></th>
+                <th class="col col-1">Carta</th>
+                <th class="col col-1"></th>
             </tr>
             <tr class="row clickable-row" *ngFor="let player of players">
                 <td class="col col-1" (click)="editPlayer(player.id)">{{player.number}}</td>
-                <td class="col col-4" (click)="editPlayer(player.id)">
+                <td class="col col-6" (click)="editPlayer(player.id)">
                     {{player.name}}
                     <span *ngIf="player.id === team?.captainId" class="captain-badge"><i class="fa fa-star"></i> Capitán</span>
                 </td>
                 <td class="col col-3" (click)="editPlayer(player.id)">{{player.position}}</td>
                 <!-- Waiver availability; click the icon to view it. Nothing is
                      shown when no waiver has been uploaded. -->
-                <td class="col col-2">
+                <td class="col col-1">
                     <a *ngIf="player.liabilityWaiver" class="waiver-link" [routerLink]="" title="Ver carta responsiva"
                        (click)="viewWaiver(player, $event)">
                         <i class="fas fa-file-lines"></i>
                     </a>
                 </td>
-                <td class="col col-2 text-end">
+                <td class="col col-1 text-end">
                   <button class="btn btn-outline-danger btn-sm btn-floating" title="Remover jugador" (click)="removePlayer(player.id)" role="button">
                     <i class="fa fa-remove"></i>
                   </button>

--- a/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
+++ b/angular-app/src/app/restricted-area/view-teams/view-teams.component.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'buffer';
 import { Component, EventEmitter, Input, Output, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { AuthService } from '../../auth.service';
 import { DynamoDb } from '../../aws-clients/dynamodb';
 import { TeamBuilder } from '../../Builders/team-builder';
@@ -35,12 +36,22 @@ export class ViewTeamsComponent {
   displayPaymentReceipt = "none";
   addExistingPlayerForm: FormGroup;
 
+  // Waiver viewer shown from the roster's "Carta" column.
+  displayWaiver = "none";
+  loadingWaiver = false;
+  waiverUrl: string | undefined;
+  waiverSafeUrl: SafeResourceUrl | undefined;
+  waiverIsPdf = false;
+  waiverError = "";
+  waiverPlayerName = "";
+
   constructor(private fb: FormBuilder,
     private authService: AuthService,
     private teamBuilder: TeamBuilder,
     private userBuilder: UserBuilder,
     private playerBuilder: PlayerBuilder,
-    private featureFlagBuilder: FeatureFlagBuilder
+    private featureFlagBuilder: FeatureFlagBuilder,
+    private sanitizer: DomSanitizer
   ){
     this.selectedPlayer=this.playerBuilder.getEmptyPlayer();
     this.addExistingPlayerForm = this.fb.group({
@@ -453,8 +464,37 @@ export class ViewTeamsComponent {
   }
   async removePlayer(playerId: string){
     await this.playerBuilder.updatePlayerYear(this.ddb, playerId, "removed", this.team!.id, this.team!.category!)
-    
+
     await this.loadTeam(this.team?.id!);
+  }
+
+  // Show a player's signed waiver in a modal. Stops the click from also opening
+  // the player editor, since the whole row is clickable.
+  async viewWaiver(player: Player, event: Event){
+    event.stopPropagation();
+
+    this.waiverUrl = undefined;
+    this.waiverSafeUrl = undefined;
+    this.waiverError = "";
+    this.waiverPlayerName = player.name;
+    this.loadingWaiver = true;
+    this.displayWaiver = "block";
+
+    const result = await this.playerBuilder.loadLiabilityWaiver(this.s3, player);
+    if (result) {
+      this.waiverIsPdf = result.isPdf;
+      this.waiverUrl = result.url;
+      this.waiverSafeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(result.url);
+    } else {
+      this.waiverError = "No se pudo cargar la carta responsiva.";
+    }
+    this.loadingWaiver = false;
+  }
+
+  closeWaiver(){
+    this.displayWaiver = "none";
+    this.waiverUrl = undefined;
+    this.waiverSafeUrl = undefined;
   }
 
   async addPlayer(){

--- a/angular-app/src/styles.scss
+++ b/angular-app/src/styles.scss
@@ -422,6 +422,18 @@ td{
     }
 }
 
+// Waiver ("Carta Responsiva") download icon in the player tables. Only rendered
+// when a waiver exists, so the empty cell itself means "not uploaded".
+.waiver-link{
+    color: $bg-color1;
+    text-decoration: none;
+    cursor: pointer;
+
+    &:hover{
+        color: darken($bg-color1, 15%);
+    }
+}
+
 .scroll-container {
     overflow-x: scroll; /* Enables horizontal scrolling when content overflows */
     -webkit-overflow-scrolling: touch; /* Improves scrolling on iOS devices */


### PR DESCRIPTION
- Clear pending photo/waiver uploads when switching players in the player editor; the modal is only hidden, so the component kept the previously picked file and uploaded it under the next player's id
- Add a "Carta" column to the team roster and Jugadores Registrados showing an icon only when a waiver exists, opening it in a viewer modal
- Make the Jugadores Registrados "Carta" column sortable by availability