### PR TITLE
Size the scouting evaluation modal and limit jersey to 3 digits

### DIFF
--- a/angular-app/src/app/restricted-area/evaluacion/evaluacion.component.html
+++ b/angular-app/src/app/restricted-area/evaluacion/evaluacion.component.html
@@ -1,5 +1,5 @@
 <div class="row justify-content-md-center">
-<div class="col-12 col-md-6">
+<div class="col-12" [class.col-md-6]="!fullWidth">
   <h2 class="text-center mb-3">
     Evaluacion de Jugadores
 </h2>

--- a/angular-app/src/app/restricted-area/evaluacion/evaluacion.component.ts
+++ b/angular-app/src/app/restricted-area/evaluacion/evaluacion.component.ts
@@ -37,6 +37,9 @@ export class EvaluacionComponent implements OnChanges {
   // Optional pre-selected player (e.g. clicked from the scouting roster). When
   // set, the component auto-selects it and loads its existing report.
   @Input() player: Player | null | undefined = null;
+  // Set when hosted inside a modal, which already limits the width. The
+  // half-width column is only meant for the standalone page.
+  @Input() fullWidth = false;
 
   scout_id = this.authService.getUserId();
   scout_name = this.authService.getUserName();

--- a/angular-app/src/app/restricted-area/scouting/scouting.component.html
+++ b/angular-app/src/app/restricted-area/scouting/scouting.component.html
@@ -237,7 +237,7 @@
   tabindex="-1"
   role="dialog"
   [ngStyle]="{'display':displayEvalPlayer}" *ngIf="isEvaluatingPlayer">
-  <div class="modal-dialog" role="document">
+  <div class="modal-dialog eval-modal modal-dialog-scrollable" role="document">
     <div class="modal-content">
       <div class="modal-header dark-header">
         <h5 class="modal-title">Evaluar Jugador</h5>
@@ -249,7 +249,8 @@
           [ddb]="ddb" [s3]="s3"
           [category]="editingTeam.category"
           [team]="editingTeam.name"
-          [player]="selectedPlayer"></app-evaluacion>
+          [player]="selectedPlayer"
+          [fullWidth]="true"></app-evaluacion>
       </div>
     </div>
   </div>

--- a/angular-app/src/app/restricted-area/scouting/scouting.component.scss
+++ b/angular-app/src/app/restricted-area/scouting/scouting.component.scss
@@ -31,6 +31,19 @@ fieldset {
     color: black;
 }
 
+// The evaluation form is also shown full-page on the Jugador tab, where it sits
+// in a `col-md-6` inside Bootstrap's `.container`. Match those widths — half the
+// container per breakpoint, plus the modal body's 1rem side padding — so the
+// form renders at the same size in both places.
+// Below 768px the form is full-width on the tab too, so Bootstrap's default
+// sizing already matches and is left alone.
+.eval-modal{
+    @media (min-width: 768px){ max-width: none; width: 392px; }  // container 720 / 2 + 32
+    @media (min-width: 992px){ width: 512px; }                   // container 960 / 2 + 32
+    @media (min-width: 1200px){ width: 602px; }                  // container 1140 / 2 + 32
+    @media (min-width: 1400px){ width: 692px; }                  // container 1320 / 2 + 32
+}
+
 .player-card{
     background-color: $bg-color2;
     border-color: $bg-color1;

--- a/angular-app/src/app/restricted-area/view-teams/add-player/add-player.component.html
+++ b/angular-app/src/app/restricted-area/view-teams/add-player/add-player.component.html
@@ -23,7 +23,8 @@
       </div>
 
       <label class="frow" for="numero">Número de Jersey:&nbsp;</label>
-      <input class="frow" formControlName="numero" class="form-control" type="number" min="0" max="99" value="{{player.number}}">
+      <input class="frow" formControlName="numero" class="form-control" type="text" inputmode="numeric"
+             maxlength="3" (input)="onJerseyInput($event)" value="{{player.number}}">
       <label class="frow" for="curp">CURP:&nbsp;</label>
       <input class="frow" formControlName="curp" class="form-control" type="text" value="{{player.curp}}">
       <label class="frow" for="altura">Altura (cm):&nbsp;</label>

--- a/angular-app/src/app/restricted-area/view-teams/add-player/add-player.component.ts
+++ b/angular-app/src/app/restricted-area/view-teams/add-player/add-player.component.ts
@@ -145,6 +145,17 @@ export class AddPlayerComponent {
     }
   }
 
+  // Jersey numbers are at most 3 digits. `maxlength` alone does not cover
+  // pasted text or non-digit characters, so strip anything else as it is typed.
+  onJerseyInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const digits = input.value.replace(/\D/g, '').slice(0, 3);
+    if (digits !== input.value) {
+      input.value = digits;
+    }
+    this.playerForm.controls.numero.setValue(digits);
+  }
+
   togglePosition(position: string): void {
     this.selectedPositions[position] = !this.selectedPositions[position];
   }


### PR DESCRIPTION
The evaluation modal from the team roster was capped at Bootstrap's default 500px. Give it explicit per-breakpoint widths matching the same form on the Jugador tab, and let the shared component skip its own half-width column when hosted in a modal.

The jersey input also allowed any length, since type=number ignores maxlength; use a text input that strips non-digits and caps at 3.