### PR TITLE
Default new match time to now in 10-minute steps & Update group names

### DIFF
--- a/angular-app/src/app/Builders/match-builder.ts
+++ b/angular-app/src/app/Builders/match-builder.ts
@@ -8,6 +8,7 @@ import {v4 as uuidv4} from 'uuid';
 import { TOURNAMENT_YEAR } from '../aws-clients/constants';
 import { GymBuilder } from './gym-builder';
 import { Gym } from '../interfaces/gym';
+import { toLocalDateTimeString } from '../utils/utils';
 
 @Injectable({
     providedIn: 'root'
@@ -177,7 +178,8 @@ export class MatchBuilder {
         record['homePoints'] = {S: `0`};
         record['visitorPoints'] = {S: `0`};
         record['time'] = {S:`${new Date(time!).toLocaleTimeString([],{timeStyle: 'short'})}`};
-        record['datetime'] = {S: `${time}`};
+        // Stored zone-less so the match keeps the wall-clock time it was entered with.
+        record['datetime'] = {S: toLocalDateTimeString(new Date(time!))};
         record['juego'] = {S: `${juego}`};
         record['braketPlace'] = {S: `${bracket}`};
         record[CY_KEY] = {S: TOURNAMENT_YEAR};

--- a/angular-app/src/app/Builders/match-builder.ts
+++ b/angular-app/src/app/Builders/match-builder.ts
@@ -63,7 +63,7 @@ export class MatchBuilder {
             category: item['category'].S,
             location: gym,
             day: item['spk'].S!,
-            time: item['datetime'] ? (new Date(item['datetime'].S!)).toLocaleString("en-US",{dateStyle: 'short', timeStyle: 'short'}) : item['time'].S!,
+            time: item['datetime'] ? (new Date(item['datetime'].S!)).toLocaleString("es-MX",{dateStyle: 'short', timeStyle: 'short'}) : item['time'].S!,
             datetime: item['datetime'] ? new Date(item['datetime'].S!) : undefined,
             juego: item['juego'].S!,
             visitorPoints: item['visitorPoints'].S!,

--- a/angular-app/src/app/restricted-area/match-editor/match-editor.component.html
+++ b/angular-app/src/app/restricted-area/match-editor/match-editor.component.html
@@ -49,9 +49,11 @@
                 <div class="row">
                     <div class="filterPadding">
                         <!--input type="text" class="form-control" id="time" name="time" formControlName="time"-->
+                        <!-- step=600s: minutes are picked in 10-minute increments. -->
                         <input class="form-control" id="time" name="time" formControlName="time"
-                            type="datetime-local" 
-                            [min]="minDateTime" 
+                            type="datetime-local"
+                            step="600"
+                            [min]="minDateTime"
                             [max]="maxDateTime">
                     </div>
                 </div>

--- a/angular-app/src/app/restricted-area/match-editor/match-editor.component.ts
+++ b/angular-app/src/app/restricted-area/match-editor/match-editor.component.ts
@@ -11,6 +11,28 @@ import { Team } from '../../interfaces/team';
 import { TOURNAMENT_DAYS, TOURNAMENT_YEAR } from 'src/app/aws-clients/constants';
 import { filterMatches } from 'src/app/utils/utils';
 
+// Match times are picked in 10-minute increments (see the input's `step`), so
+// round to the nearest one.
+function roundToTenMinutes(date: Date): Date {
+  const rounded = new Date(date);
+  rounded.setSeconds(0, 0);
+  rounded.setMinutes(Math.round(rounded.getMinutes() / 10) * 10);
+  return rounded;
+}
+
+// `datetime-local` inputs only accept `YYYY-MM-DDTHH:mm`, and it must be built
+// from the local parts: an ISO string is UTC and would shift the value.
+function toDateTimeLocal(date: Date): string {
+  const pad = (value: number) => `${value}`.padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+    + `T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+// The default shown when the form opens or is reset after a submit.
+function defaultMatchTime(): string {
+  return toDateTimeLocal(roundToTenMinutes(new Date()));
+}
+
 @Component({
   selector: 'app-match-editor',
   templateUrl: './match-editor.component.html',
@@ -158,14 +180,14 @@ export class MatchEditorComponent implements OnInit {
     hometeam: null,
     visitorteam: null,
     gym: null,
-    time: new Date(),
+    time: defaultMatchTime(),
     juego: null,
     bracket: null
   });
 
 newMatchTeams: Team[] = [];
 selectedCategoria = "";
-phases = ["Grupo 1", "Grupo 2", "Grupo 3", "Grupo 4", "Octavos", "Cuartos", "Semi-Finaless", "Finales", "Standing"]
+phases = ["Grupo A", "Grupo B", "Grupo C", "Octavos", "Cuartos", "Semi-Finaless", "Finales", "Standing"]
 brackets = ["grupos", "o1", "o2", "o3", "o4", "o5", "o6", "o7", "o8", "q9", "q10", "q11", "q12", "s13", "s14", "f15", "p16", "p17", "p18", "p19", "p20", "p21", "f22" ]
 displayStyle = "none";
 popUpMsg = "";
@@ -203,11 +225,12 @@ async onSubmitNewTeam(){
   try {
     let matchTime = new Date(this.matchForm.value.time!);
     let day = matchTime.getDate()
-    await this.matchBuilder.addMatch(this.ddb, this.matchForm.value.categoria!, this.matchForm.value.juego!, this.matchForm.value.bracket!, this.matchForm.value.hometeam!, this.matchForm.value.visitorteam!, day.toString(), this.matchForm.value.time!, this.matchForm.value.gym!)
+    await this.matchBuilder.addMatch(this.ddb, this.matchForm.value.categoria!, this.matchForm.value.juego!, this.matchForm.value.bracket!, this.matchForm.value.hometeam!, this.matchForm.value.visitorteam!, day.toString(), matchTime, this.matchForm.value.gym!)
     console.warn ('Saved sucessfully!')
     this.popUpMsg = "Partido Registrado!";
     this.openPopup();
-    this.matchForm.reset();
+    // Reset back to the current date and time rather than an empty field.
+    this.matchForm.reset({categoria: 'aprendiz', time: defaultMatchTime()});
 
   } catch (err) {
     console.error("Error Submitting report")

--- a/angular-app/src/app/restricted-area/match-editor/match-editor.component.ts
+++ b/angular-app/src/app/restricted-area/match-editor/match-editor.component.ts
@@ -9,7 +9,7 @@ import { TeamBuilder } from '../../Builders/team-builder';
 import { DynamoDb } from '../../aws-clients/dynamodb';
 import { Team } from '../../interfaces/team';
 import { TOURNAMENT_DAYS, TOURNAMENT_YEAR } from 'src/app/aws-clients/constants';
-import { filterMatches } from 'src/app/utils/utils';
+import { filterMatches, toLocalDateTimeString } from 'src/app/utils/utils';
 
 // Match times are picked in 10-minute increments (see the input's `step`), so
 // round to the nearest one.
@@ -20,17 +20,10 @@ function roundToTenMinutes(date: Date): Date {
   return rounded;
 }
 
-// `datetime-local` inputs only accept `YYYY-MM-DDTHH:mm`, and it must be built
-// from the local parts: an ISO string is UTC and would shift the value.
-function toDateTimeLocal(date: Date): string {
-  const pad = (value: number) => `${value}`.padStart(2, '0');
-  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
-    + `T${pad(date.getHours())}:${pad(date.getMinutes())}`;
-}
-
-// The default shown when the form opens or is reset after a submit.
+// The default shown when the form opens or is reset after a submit. The
+// zone-less format is also what the `datetime-local` input expects.
 function defaultMatchTime(): string {
-  return toDateTimeLocal(roundToTenMinutes(new Date()));
+  return toLocalDateTimeString(roundToTenMinutes(new Date()));
 }
 
 @Component({

--- a/angular-app/src/app/utils/utils.ts
+++ b/angular-app/src/app/utils/utils.ts
@@ -5,6 +5,17 @@ export function generateId(): string {
     return uuid()
 }
 
+// Match times are wall-clock times at the venue, so they are stored without a
+// zone: `YYYY-MM-DDTHH:mm`. `Date.toString()` would embed the writer's offset
+// and `toISOString()` would convert to UTC — either way the saved hour shifts
+// depending on where it was entered. Reading it back with `new Date(...)` parses
+// it as local time, giving the same clock time it was saved with.
+export function toLocalDateTimeString(date: Date): string {
+    const pad = (value: number) => `${value}`.padStart(2, '0');
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+        + `T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
 export function filterMatches(
     matches: Match[], 
      day: string | null = null,


### PR DESCRIPTION
The datetime-local input was initialized with a Date object, which it cannot render, so the field opened empty. Seed it with the string format the input expects, rounded to the nearest 10 minutes to stay in step, and restore that default after a submit instead of clearing the field.

Also rename the group phases to Grupo A/B/C.