### PR TITLE
Add public standings cross table with category and team filters

### DIFF
--- a/angular-app/src/app/app-routing.module.ts
+++ b/angular-app/src/app/app-routing.module.ts
@@ -14,6 +14,7 @@ import { EvaluacionComponent } from './restricted-area/evaluacion/evaluacion.com
 import { GroupsComponent } from './results/groups/groups.component';
 import { BracketsComponent } from './results/brackets/brackets.component';
 import { StandingMatchesComponent } from './results/standing-matches/standing-matches.component';
+import { StandingsComponent } from './results/standings/standings.component';
 import { SignupComponent } from './signup/signup.component';
 import { LoginComponent } from './login/login.component';
 import { RestrictedAreaComponent } from './restricted-area/restricted-area.component';
@@ -40,6 +41,7 @@ const routes: Routes = [
   { path: 'grupos', component: GroupsComponent },
   { path: 'brackets', component: BracketsComponent },
   { path: 'standings', component: StandingMatchesComponent },
+  { path: 'tabla', component: StandingsComponent },
   { path: 'signup', component: SignupComponent },
   { path: 'partidos', component: PartidosComponent },
   { path: '**', component: InicioComponent, data: { 

--- a/angular-app/src/app/app.component.html
+++ b/angular-app/src/app/app.component.html
@@ -28,6 +28,7 @@
             <ul class="dropdown-menu">
               <li><a class="dropdown-item" [hidden]="hideParticipants" routerLink="participantes">Equipos Registrados</a></li>
               <li><a class="dropdown-item" routerLink="partidos">Partidos</a></li>
+              <li><a class="dropdown-item" routerLink="tabla">Tabla de Resultados</a></li>
               <li><a class="dropdown-item" routerLink="results">Torneos Anteriores</a></li>
             </ul>
           </li>

--- a/angular-app/src/app/app.module.ts
+++ b/angular-app/src/app/app.module.ts
@@ -40,6 +40,7 @@ import { GroupsComponent } from './results/groups/groups.component';
 import { MatchGeneratorComponent } from './restricted-area/match-generator/match-generator.component';
 import { MatchEditorComponent } from './restricted-area/match-editor/match-editor.component';
 import { StandingMatchesComponent } from './results/standing-matches/standing-matches.component';
+import { StandingsComponent } from './results/standings/standings.component';
 import { AddPlayerComponent } from './restricted-area/view-teams/add-player/add-player.component';
 import { AddTeamComponent } from './restricted-area/add-team/add-team.component';
 import { SignupComponent } from './signup/signup.component';
@@ -79,6 +80,7 @@ import { ReportsComponent } from './restricted-area/reports/reports.component'
     MatchGeneratorComponent,
     MatchEditorComponent,
     StandingMatchesComponent,
+    StandingsComponent,
     AddPlayerComponent,
     AddTeamComponent,
     SignupComponent,

--- a/angular-app/src/app/results/standings/standings.component.html
+++ b/angular-app/src/app/results/standings/standings.component.html
@@ -1,0 +1,78 @@
+<div class="row justify-content-md-center padded-page">
+    <div class="col col-12">
+        <h1 class="text-center">
+            Tabla de Resultados
+        </h1>
+        <br>
+    </div>
+
+    <div class="spinner-border text-light mx-auto" role="status" *ngIf="loading">
+        <span class="sr-only">Loading...</span>
+    </div>
+
+    <div [hidden]="loading">
+        <!-- Category filter (same control the partidos page uses) plus a team
+             filter that narrows the tables down to a single team's row. -->
+        <div class="col col-12 results-filters">
+            <div class="year-select">
+                <select id="categorySelect" class="year-select__control" [formControl]="category" (change)="selectCategory()">
+                    <option *ngFor="let cat of categories" [value]="cat">{{cat | titlecase}}</option>
+                </select>
+            </div>
+
+            <div class="year-select" *ngIf="teams.length > 0">
+                <select id="teamSelect" class="year-select__control" [formControl]="team" (change)="selectTeam()">
+                    <option value="">Todos los equipos</option>
+                    <option *ngFor="let filterTeam of teams" [value]="filterTeam.id">{{filterTeam.name}}</option>
+                </select>
+            </div>
+        </div>
+
+        <h2 *ngIf="!loading && standings.length === 0" class="text-center">
+            Próximamente, estad atentos.
+        </h2>
+
+        <!-- One cross table per group: columns and rows are the same team list,
+             so the diagonal is the team against itself and is blacked out. -->
+        <div class="col col-12 standings-group" *ngFor="let groupStandings of standings">
+            <div class="scroll-container">
+                <table class="standings-table">
+                    <!-- Every cell's content is wrapped in .standings-cell, a fixed
+                         two-line box, so all rows end up exactly the same height. -->
+                    <thead>
+                        <tr>
+                            <th class="standings-table__corner">
+                                <div class="standings-cell"><span class="standings-cell__text">{{groupStandings.group}}</span></div>
+                            </th>
+                            <th *ngFor="let team of groupStandings.teams">
+                                <div class="standings-cell"><span class="standings-cell__text">{{team.name}}</span></div>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr *ngFor="let rowTeam of groupStandings.rowTeams">
+                            <th class="standings-table__row-header">
+                                <div class="standings-cell"><span class="standings-cell__text">{{rowTeam.name}}</span></div>
+                            </th>
+                            <ng-container *ngFor="let columnTeam of groupStandings.teams">
+                                <td *ngIf="rowTeam.id === columnTeam.id" class="standings-table__self">
+                                    <div class="standings-cell"></div>
+                                </td>
+                                <td *ngIf="rowTeam.id !== columnTeam.id">
+                                    <div class="standings-cell">
+                                        <span class="standings-cell__text standings-result"
+                                              *ngIf="groupStandings.results[rowTeam.id][columnTeam.id] as cell"
+                                              [class.standings-result--win]="cell.outcome === 'G'"
+                                              [class.standings-result--loss]="cell.outcome === 'P'">
+                                            {{cell.outcome}} {{cell.teamPoints}} - {{cell.opponentPoints}}
+                                        </span>
+                                    </div>
+                                </td>
+                            </ng-container>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/angular-app/src/app/results/standings/standings.component.scss
+++ b/angular-app/src/app/results/standings/standings.component.scss
@@ -1,0 +1,177 @@
+@import "colors";
+
+.padded-page{
+    padding: 5%;
+}
+
+// Category filter, aligned to the top-left above the tables (same control as
+// the partidos page).
+.results-filters {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem 1rem;
+    margin-bottom: 1.25rem;
+}
+
+.year-select {
+    position: relative;
+    display: inline-block;
+
+    &::after {
+        content: '';
+        position: absolute;
+        top: 50%;
+        right: 1rem;
+        width: 0.5em;
+        height: 0.5em;
+        border-right: 2px solid $bg-color1;
+        border-bottom: 2px solid $bg-color1;
+        transform: translateY(-70%) rotate(45deg);
+        pointer-events: none;
+    }
+}
+
+.year-select__control {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    padding: 0.5rem 2.5rem 0.5rem 1rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: $bg-color1;
+    background-color: $bg-color2;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    cursor: pointer;
+    outline: none;
+    transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+
+    &:hover {
+        border-color: $header-color1;
+    }
+
+    &:focus {
+        border-color: $header-color1;
+        box-shadow: 0 0 0 0.2rem $focus-ring-color;
+    }
+}
+
+.standings-group {
+    margin-bottom: 2.5rem;
+}
+
+// Fixed column widths. The first column is sized so team names wrap into at most
+// two lines: at this width two lines hold ~44 characters, comfortably more than
+// any current team name.
+$row-header-width: 14rem;
+$result-column-width: 10.5rem;
+
+// Every cell is exactly two lines tall so all rows line up, whether the team
+// name wraps or not.
+$cell-line-height: 1.3rem;
+$cell-lines: 2;
+
+// Cross table: the top-left corner cell carries the group name, the first row
+// and first column are the team headers, and the diagonal (team vs itself) is
+// blacked out.
+.standings-table {
+    // `table-layout: auto` with matching min/max widths per cell, rather than
+    // `fixed` + `width`: under `fixed` the table sizes to its container first and
+    // then divides that width among the columns, so every column shrinks on a
+    // narrow screen. Clamping min and max pins each column at one width at any
+    // viewport and lets the table overflow into .scroll-container instead.
+    table-layout: auto;
+    width: auto;
+    border-collapse: separate;
+    border-spacing: 0;
+    color: $bg-color1;
+
+    th, td {
+        min-width: $result-column-width;
+        max-width: $result-column-width;
+        padding: 0.4rem 0.5rem;
+        border: 1px solid $bg-color1;
+        vertical-align: middle;
+    }
+
+    // Column headers: the opponents. The corner is excluded so its own, darker
+    // treatment below wins — view-encapsulation attributes would otherwise make
+    // this two-element selector the more specific one.
+    thead th:not(.standings-table__corner) {
+        background-color: $header-color1;
+        color: $bg-color1;
+        font-weight: 700;
+        text-align: center;
+    }
+
+    // Row headers: the team the results are read from. Wider than the result
+    // columns, since these hold the team names.
+    .standings-table__row-header {
+        min-width: $row-header-width;
+        max-width: $row-header-width;
+        background-color: $header-color1;
+        color: $bg-color1;
+        font-weight: 700;
+
+        .standings-cell {
+            justify-content: flex-end;
+        }
+
+        .standings-cell__text {
+            text-align: right;
+        }
+    }
+
+    // Group name sits in the empty corner above the row headers. Dark panel with
+    // the brand yellow on top so it reads as the table's title, not as a team.
+    th.standings-table__corner {
+        min-width: $row-header-width;
+        max-width: $row-header-width;
+        background-color: $bg-color1;
+        color: $header-color1;
+        font-weight: 800;
+        font-size: 1rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        text-align: center;
+    }
+
+    td {
+        background-color: $bg-color2;
+        text-align: center;
+    }
+
+    // A team never plays itself, so the diagonal is filled in solid.
+    .standings-table__self {
+        background-color: $bg-color1;
+    }
+
+    // Every cell's content lives in this box, fixed at two lines tall so all rows
+    // are the same height, with the text centered inside it.
+    .standings-cell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: $cell-line-height * $cell-lines;
+    }
+
+    // Team names wrap onto a second line rather than widening the column. No
+    // clamp or max-height here: the two lines the cell provides are enough for
+    // every name at this column width, and leaving the text unclamped means an
+    // unexpectedly long one stays readable instead of being silently cut off.
+    .standings-cell__text {
+        line-height: $cell-line-height;
+        text-align: center;
+        // Set explicitly because .scroll-container sets nowrap on its subtree.
+        white-space: normal;
+        overflow-wrap: break-word;
+    }
+}
+
+.standings-result {
+    font-weight: 600;
+
+    &--win { color: darken($text-color1, 20%); }
+    &--loss { color: $text-color2; }
+}

--- a/angular-app/src/app/results/standings/standings.component.spec.ts
+++ b/angular-app/src/app/results/standings/standings.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { StandingsComponent } from './standings.component';
+
+describe('StandingsComponent', () => {
+  let component: StandingsComponent;
+  let fixture: ComponentFixture<StandingsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ StandingsComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(StandingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular-app/src/app/results/standings/standings.component.ts
+++ b/angular-app/src/app/results/standings/standings.component.ts
@@ -1,0 +1,219 @@
+import { Component, OnInit } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { Match } from '../../interfaces/match';
+import { Category, MatchTeam } from '../../interfaces/team';
+import { MatchBuilder } from '../../Builders/match-builder';
+import { DynamoDb } from '../../aws-clients/dynamodb';
+import { COGNITO_UNAUTHENTICATED_CREDENTIALS, TOURNAMENT_YEAR, REGION } from '../../aws-clients/constants'
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+
+// One result as seen from the row team's point of view: "G 44 - 38" means the
+// row team won 44 to 38. Cells stay undefined when the pairing hasn't been
+// played yet, which is what leaves the blanks in the table.
+export interface StandingsCell {
+  outcome: 'G' | 'P' | 'E';
+  teamPoints: number;
+  opponentPoints: number;
+}
+
+// A group's cross table. `teams` are the columns (always the whole group, so a
+// team's results stay readable against every opponent) and `rowTeams` are the
+// rows — the same list, unless the team filter narrows it to one. `results` is
+// indexed [rowTeamId][columnTeamId].
+export interface GroupStandings {
+  group: string;
+  teams: MatchTeam[];
+  rowTeams: MatchTeam[];
+  results: {[rowTeamId: string]: {[columnTeamId: string]: StandingsCell | undefined}};
+}
+
+@Component({
+  selector: 'app-standings',
+  templateUrl: './standings.component.html',
+  styleUrls: ['./standings.component.scss']
+})
+
+export class StandingsComponent implements OnInit {
+  ddbClient = new DynamoDBClient({
+    region: REGION,
+    credentials: COGNITO_UNAUTHENTICATED_CREDENTIALS
+  });
+  ddb: DynamoDb = new DynamoDb(this.ddbClient);
+
+  loading = true;
+
+  // Same group names (and order) the group-phase match list uses.
+  groups = ["Grupo 1", "Grupo 2", "Grupo 3", "Grupo 4", "Grupo A", "Grupo B", "Grupo C"]
+
+  // Elite first, matching the filter on the partidos page. (Listed explicitly
+  // rather than via getCategories(), which returns aprendiz first.)
+  categories: Category[] = [Category.ELITE, Category.APRENDIZ];
+  selectedCategory: Category = Category.ELITE;
+  category = new FormControl<Category>(Category.ELITE);
+
+  // Built cross tables per category, so switching the filter doesn't refetch.
+  standingsByCategory: Partial<Record<Category, GroupStandings[]>> = {};
+
+  // Every team playing the group phase in each category, for the team filter.
+  teamsByCategory: Partial<Record<Category, MatchTeam[]>> = {};
+
+  // Empty means "all teams"; otherwise the id of the team to narrow down to.
+  selectedTeamId = "";
+  team = new FormControl<string>("");
+
+  // What the template renders: the selected category's tables with the team
+  // filter applied. Kept in sync by applyFilters().
+  standings: GroupStandings[] = [];
+
+  selectedYear = "";
+
+  constructor(private matchBuilder: MatchBuilder) {
+  }
+
+  async ngOnInit() {
+    await this.loadMatches(TOURNAMENT_YEAR);
+  }
+
+  selectCategory() {
+    this.selectedCategory = this.category.value!;
+    // The team lists don't overlap between categories, so a team picked in the
+    // old one would filter everything away. Back to "all teams".
+    this.clearTeam();
+  }
+
+  selectTeam() {
+    this.selectedTeamId = this.team.value ?? "";
+    this.applyFilters();
+  }
+
+  clearTeam() {
+    this.selectedTeamId = "";
+    this.team.setValue("");
+    this.applyFilters();
+  }
+
+  // Teams of the selected category, for the team dropdown.
+  get teams(): MatchTeam[] {
+    return this.teamsByCategory[this.selectedCategory] ?? [];
+  }
+
+  // Recomputed only when a filter changes, rather than exposed as a getter: the
+  // team filter builds new GroupStandings objects, and a getter would hand
+  // *ngFor a different object every change-detection pass and rebuild the tables.
+  private applyFilters() {
+    const standings = this.standingsByCategory[this.selectedCategory] ?? [];
+
+    if (!this.selectedTeamId) {
+      this.standings = standings;
+      return;
+    }
+
+    // Only the selected team's group is shown, and only its row within it. The
+    // columns stay the whole group so the row still reads as "us against each
+    // opponent".
+    this.standings = standings
+      .filter(groupStandings => groupStandings.teams.some(team => team.id === this.selectedTeamId))
+      .map(groupStandings => ({
+        ...groupStandings,
+        rowTeams: groupStandings.teams.filter(team => team.id === this.selectedTeamId)
+      }));
+  }
+
+  async loadMatches(year: string) {
+    this.loading = true;
+    this.selectedYear = year;
+    this.standingsByCategory = {};
+    this.teamsByCategory = {};
+    this.clearTeam();
+
+    const allMatches = await this.matchBuilder.getListOfMatch(this.ddb, year);
+
+    const groupMatches = allMatches.filter(match => this.groups.includes(match.juego));
+
+    this.categories.forEach(category => {
+      const standings = this.buildStandings(
+        groupMatches.filter(match => match.category === category)
+      );
+      this.standingsByCategory[category] = standings;
+      this.teamsByCategory[category] = this.collectFilterTeams(standings);
+    });
+
+    // clearTeam() above ran before the tables existed, so pick them up now.
+    this.applyFilters();
+
+    this.loading = false;
+  }
+
+  // Flattens the per-group team lists into one alphabetical list for the team
+  // dropdown. A team only ever belongs to one group, so there's nothing to dedupe.
+  private collectFilterTeams(standings: GroupStandings[]): MatchTeam[] {
+    return standings
+      .flatMap(groupStandings => groupStandings.teams)
+      .sort((a, b) => a.name.localeCompare(b.name, 'es'));
+  }
+
+  // Turns a flat match list into one cross table per group. Groups with no
+  // matches are dropped so the page only renders what actually exists.
+  private buildStandings(matches: Match[]): GroupStandings[] {
+    return this.groups
+      .map(group => this.buildGroupStandings(group, matches.filter(match => match.juego === group)))
+      .filter(standings => standings.teams.length > 0);
+  }
+
+  private buildGroupStandings(group: string, matches: Match[]): GroupStandings {
+    const teams = new Map<string, MatchTeam>();
+    const results: GroupStandings['results'] = {};
+
+    for (const match of matches) {
+      // A single-team entry is a bye — it has no opponent to score against.
+      if (match.singleTeam) {
+        this.collectTeam(teams, results, match.homeTeam);
+        continue;
+      }
+
+      this.collectTeam(teams, results, match.homeTeam);
+      this.collectTeam(teams, results, match.visitorTeam);
+
+      const homePoints = Number(match.homePoints ?? 0);
+      const visitorPoints = Number(match.visitorPoints ?? 0);
+
+      // 0-0 is the score a match is created with, so treat it as "not played
+      // yet" and leave the pair of cells blank.
+      if (!homePoints && !visitorPoints) {
+        continue;
+      }
+
+      results[match.homeTeam.id][match.visitorTeam.id] = this.buildCell(homePoints, visitorPoints);
+      results[match.visitorTeam.id][match.homeTeam.id] = this.buildCell(visitorPoints, homePoints);
+    }
+
+    const sortedTeams = [...teams.values()].sort((a, b) => a.name.localeCompare(b.name, 'es'));
+
+    // Unfiltered, every team is also a row; the team filter narrows this down.
+    return {
+      group,
+      teams: sortedTeams,
+      rowTeams: sortedTeams,
+      results
+    };
+  }
+
+  private collectTeam(
+    teams: Map<string, MatchTeam>,
+    results: GroupStandings['results'],
+    team: MatchTeam | undefined
+  ) {
+    if (!team?.id) return;
+    if (!teams.has(team.id)) {
+      teams.set(team.id, team);
+      results[team.id] = {};
+    }
+  }
+
+  private buildCell(teamPoints: number, opponentPoints: number): StandingsCell {
+    let outcome: StandingsCell['outcome'] = 'E';
+    if (teamPoints > opponentPoints) outcome = 'G';
+    if (teamPoints < opponentPoints) outcome = 'P';
+    return { outcome, teamPoints, opponentPoints };
+  }
+}


### PR DESCRIPTION
New Tabla de Resultados page (route: tabla) that pivots the group-phase matches into one cross table per group, read from the row team's point of view. Cells stay blank for pairings that haven't been played, since matches are created with a 0-0 score.

Filters by category and, optionally, by a single team — which narrows the tables to that team's group and its row within it, keeping the full group as columns so the row still reads as "us against each opponent".