### PR TITLE
Make the Reportes admin view drillable by scout

### DIFF
--- a/angular-app/angular.json
+++ b/angular-app/angular.json
@@ -110,7 +110,12 @@
             "styles": [
               "src/styles.scss"
             ],
-            "scripts": []
+            "scripts": [],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "./src/"
+              ]
+            }
           }
         }
       }

--- a/angular-app/src/_evaluation-modal.scss
+++ b/angular-app/src/_evaluation-modal.scss
@@ -1,0 +1,97 @@
+@import "colors";
+
+// Shared look for the evaluation detail modals: a photo card and summary fields
+// up top, then one "score block" card per report section. Imported by the
+// components that render a player's evaluation (Estadisticas de Evaluacion and
+// Reportes) so both stay visually identical.
+
+.modern-player-modal {
+    border: 1px solid $modal-surface-strong-border;
+    border-radius: 1rem;
+    overflow: hidden;
+    background: $bg-color2;
+    color: $bg-color1;
+    box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.28);
+}
+
+.modern-player-modal .modal-header.dark-header {
+    background: $bg-color1;
+    color: $header-color1;
+    border-bottom: 0;
+}
+
+.modern-player-modal__body {
+    background: linear-gradient(180deg, $modal-surface-gradient-start, $modal-surface-gradient-end);
+    padding: 1.25rem;
+}
+
+.modern-player-modal__image-card {
+    height: 100%;
+    min-height: 240px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: $modal-surface-muted;
+    border: 1px solid $modal-surface-border;
+    border-radius: 0.9rem;
+    padding: 1rem;
+}
+
+.modern-player-modal__image {
+    max-height: 220px;
+    max-width: 100%;
+    object-fit: contain;
+    border-radius: 0.75rem;
+}
+
+.modern-player-modal__summary {
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+}
+
+.detail-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.detail-label {
+    color: $bg-color1;
+    font-weight: 700;
+    font-size: 0.82rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.playerfield {
+    background: rgba($modal-surface-color, 0.98);
+    color: $bg-color1;
+    font-weight: 700;
+    padding: 0.6rem 0.8rem;
+    border-radius: 0.65rem;
+    border: 1px solid $modal-surface-strong-border;
+    box-shadow: inset 0 1px 0 rgba($modal-surface-color, 0.65);
+}
+
+.myrow {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.myrow div {
+  margin-top: 0.35rem;
+  margin-bottom: 0.35rem;
+}
+
+.score-block {
+    padding: 0.75rem;
+    background: rgba($bg-color1, 0.04);
+    border: 1px solid $modal-surface-border;
+    border-radius: 0.75rem;
+}
+
+.modern-player-modal__footer {
+    background: $bg-color2;
+    border-top: 1px solid $modal-surface-border;
+}

--- a/angular-app/src/app/Builders/reporte-builder.ts
+++ b/angular-app/src/app/Builders/reporte-builder.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CY_KEY, DynamoDb, PK_KEY, SK_KEY, SPK_KEY, SSK_KEY } from "src/app/aws-clients/dynamodb";
-import { DisplayReport, Reporte, ReportBasic, Section, Skill, Skills, TopReporte } from "../interfaces/reporte";
+import { DisplayReport, Reporte, ReportBasic, ReportSectionView, ReportSkillView, ScoutPlayerReportView, Section, Skill, Skills, TopReporte } from "../interfaces/reporte";
 import { AttributeValue } from "@aws-sdk/client-dynamodb";
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { Scout } from '../interfaces/scout';
@@ -166,10 +166,120 @@ export class ReporteBuilder {
         let reports: ReportBasic[] = []
         reports = await ddb.listBySPKQuery(`report`, TOURNAMENT_YEAR).then(
             (items) => {
-                return items.map((item) => {return {scoutId: item['pk'].S!.substring(6), playerId: item['sk'].S!.split('player.')[1], category: item['categoria'].S!, teamName: "", playerName:"", scoutName: ""}})
+                return items.map((item) => {return {scoutId: item['pk'].S!.substring(6), playerId: item['sk'].S!.split('player.')[1], category: item['categoria'].S!, teamName: "", playerName:"", playerNumber: "", scoutName: ""}})
             }
         )
         return reports
+    }
+
+    /**
+     * Read the report a single scout submitted for a single player and flatten it
+     * into sections of localized label/value pairs for on-page display.
+     */
+    async getScoutPlayerReport(ddb: DynamoDb, scoutId: string, playerId: string): Promise<ScoutPlayerReportView> {
+        let key: Record<string, AttributeValue> = {
+            [PK_KEY]: {S: `${Role.SCOUT}.${scoutId}`},
+            [SK_KEY]: {S: `report.${TOURNAMENT_YEAR}.player.${playerId}`}
+        }
+
+        let item = await ddb.getItem(key)
+        if (item == undefined) return {general: "", sections: []}
+
+        let sections: ReportSectionView[] = []
+
+        // The overall score is shown in the summary header, not as a section.
+        let generalSkills = item[Section.GENERAL]?.M
+        let general = generalSkills == undefined ? "" :
+            Object.keys(generalSkills)
+                .map(skillName => ReporteBuilder.skillValue(Section.GENERAL, generalSkills![skillName]))
+                .find(value => value !== "") ?? ""
+
+        // Render sections in the same order the evaluation form presents them.
+        ReporteBuilder.sectionOrder.forEach((sectionName: string) => {
+            let sectionSkills = item![sectionName]?.M
+            if (sectionSkills == undefined) return
+
+            // Checkbox sections only record whether an option was picked, so the
+            // option's own name becomes the value instead of pairing it with a "Si".
+            let valueOnly = ReporteBuilder.valueOnlySections.includes(sectionName)
+
+            let skills: ReportSkillView[] = Object.keys(sectionSkills).map((skillName: string) => {
+                let label = ReporteBuilder.skillLabel(sectionName, skillName)
+                let value = ReporteBuilder.skillValue(sectionName, sectionSkills![skillName])
+                if (valueOnly) return {label: "", value: value === "" ? "" : label}
+                return {label: label, value: value}
+            }).filter(skill => skill.value !== "")
+
+            if (skills.length == 0) return
+
+            sections.push({
+                section: sectionName,
+                title: ReporteBuilder.sectionTitles[sectionName] ?? sectionName,
+                fullWidth: ReporteBuilder.fullWidthSections.includes(sectionName),
+                valueOnly: valueOnly,
+                skills: skills
+            })
+        })
+
+        return {general: general, sections: sections}
+    }
+
+    private static sectionOrder: string[] = [
+        Section.POSICION,
+        Section.TIRO,
+        Section.PASE,
+        Section.DEFENSA,
+        Section.BOTE,
+        Section.JUGADOR,
+        Section.ESTILO,
+        Section.NOMINACION,
+    ]
+
+    private static sectionTitles: {[key: string]: string} = {
+        [Section.POSICION]: 'Posicion(es)',
+        [Section.TIRO]: 'Tiro',
+        [Section.PASE]: 'Pase',
+        [Section.DEFENSA]: 'Defensa',
+        [Section.BOTE]: 'Bote',
+        [Section.JUGADOR]: 'Jugador',
+        [Section.ESTILO]: 'Estilo de Juego',
+        [Section.NOMINACION]: 'Nominacion a Premios',
+    }
+
+    // Nominaciones has long award labels, so it gets the full grid width — the
+    // same layout the evaluation results modal uses.
+    private static fullWidthSections: string[] = [Section.NOMINACION]
+
+    // Sections the scout fills in with checkboxes: the report only stores which
+    // options were checked, so the picked option's name is the value.
+    private static valueOnlySections: string[] = [
+        Section.POSICION,
+        Section.ESTILO,
+        Section.NOMINACION,
+    ]
+
+    private static skillLabel(sectionName: string, skillName: string): string {
+        let section = Skills.findSection(sectionName)
+        if (section == undefined) return skillName
+        let skill = Object.values(section).find((s: Skill) => s.report == skillName)
+        return skill?.localized ?? skillName
+    }
+
+    private static skillValue(sectionName: string, attribute: AttributeValue): string {
+        // A checked box carries no value of its own; the caller swaps in the skill
+        // name. Anything falsy drops out of the section entirely.
+        if (attribute.BOOL != undefined) return attribute.BOOL ? 'x' : ''
+
+        let raw = attribute.N ?? attribute.S
+        if (raw == undefined || raw === '') return ''
+
+        // The general section stores a 1-5 score; show the localized wording too.
+        if (sectionName == Section.GENERAL) {
+            let localized = Object.values(Skills.general).find(s => `${s.value}` == raw)?.localized
+            if (localized) return `${raw} - ${localized}`
+        }
+
+        return raw
     }
 
     transformToDisplayReport(report: Reporte): DisplayReport {

--- a/angular-app/src/app/interfaces/reporte.ts
+++ b/angular-app/src/app/interfaces/reporte.ts
@@ -5,8 +5,46 @@ export interface ReportBasic {
     scoutName: string,
     playerId: string,
     playerName: string,
+    playerNumber: string,
     category: string,
     teamName: string,
+}
+
+// One scout and every report that scout submitted, so the reports list can show
+// a single row per scout with a report count. Email/phone are blank for scouts
+// that only appear via a report (i.e. not registered for the current year).
+export interface ScoutReports {
+    scoutId: string,
+    scoutName: string,
+    email: string,
+    phone: string,
+    reports: ReportBasic[],
+}
+
+// A single scout's report for a player, flattened for display: one entry per
+// section, each with its localized skill labels and values. `fullWidth` sections
+// span the whole grid instead of sitting two-up. `valueOnly` sections are
+// checkbox pickers, so only the names of the picked options are listed — there's
+// no label/value pair to show.
+export interface ReportSectionView {
+    section: string,
+    title: string,
+    fullWidth: boolean,
+    valueOnly: boolean,
+    skills: ReportSkillView[],
+}
+
+export interface ReportSkillView {
+    label: string,
+    value: string,
+}
+
+// A whole report as rendered by the reports detail modal. `general` is pulled out
+// of the sections so it can sit in the summary header, matching the layout of the
+// evaluation results modal.
+export interface ScoutPlayerReportView {
+    general: string,
+    sections: ReportSectionView[],
 }
 
 export interface Reporte {

--- a/angular-app/src/app/restricted-area/reports/reports.component.html
+++ b/angular-app/src/app/restricted-area/reports/reports.component.html
@@ -7,24 +7,151 @@
     <span class="sr-only">Loading...</span>
 </div>
 <div class="mainpanel" *ngIf="!loading">
-    <div class="scroll-container">
-        <div style="min-width: 600px;">
-    <table class="row modern-table">
-        <tr class="row">
-            <th class="col col-1">#</th>
-            <th class="col col-3">Scout</th>
-            <th class="col col-3">(#) Jugador</th>
-            <th class="col col-3">Equipo</th>
-            <th class="col col-2">Categoria</th>
-        </tr>
-        <tr class="row" *ngFor="let report of reports; let i = index" >
-            <td class="col col-1">{{i+1}}</td>
-            <td class="col col-3">{{report.scoutName}}</td>
-            <td class="col col-3">{{report.playerName}}</td>
-            <td class="col col-3">{{report.teamName}}</td>
-            <td class="col col-2">{{report.category}}</td>
-        </tr>
-    </table>
+
+    <!-- Level 1: one row per registered scout with how many reports they
+         submitted. Scouts with no reports are listed too, showing 0, and their
+         row isn't clickable since there's nothing to drill into. -->
+    <div *ngIf="!selectedScout">
+        <div class="scroll-container">
+            <div style="min-width: 900px;">
+                <table class="row modern-table">
+                    <tr class="row">
+                        <th class="col col-1">#</th>
+                        <th class="col col-3">Scout</th>
+                        <th class="col col-2">Reportes</th>
+                        <th class="col col-4">Email</th>
+                        <th class="col col-2">Cel</th>
+                    </tr>
+                    <tr class="row" *ngFor="let scout of scoutReports; let i = index"
+                        [class.clickable-row]="scout.reports.length > 0"
+                        (click)="selectScout(scout)">
+                        <td class="col col-1">{{i+1}}</td>
+                        <td class="col col-3">{{scout.scoutName}}</td>
+                        <td class="col col-2">{{scout.reports.length}}</td>
+                        <td class="col col-4">{{scout.email}}</td>
+                        <td class="col col-2">{{scout.phone}}</td>
+                    </tr>
+                    <!-- Tournament-wide report count across every scout. -->
+                    <tr class="row total-row" *ngIf="scoutReports.length > 0">
+                        <td class="col col-1"></td>
+                        <td class="col col-3">Total</td>
+                        <td class="col col-2">{{totalReports}}</td>
+                        <td class="col col-4"></td>
+                        <td class="col col-2"></td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <p class="text-light mt-2" *ngIf="scoutReports.length == 0">No hay scouts registrados.</p>
+    </div>
+
+    <!-- Level 2: the players evaluated by the selected scout. Clicking a player
+         opens the report detail modal on top of this list. -->
+    <div *ngIf="selectedScout">
+        <div class="d-flex align-items-center gap-2 mb-3">
+            <button type="button" class="btn btn-outline-light btn-sm" (click)="backToScouts()" title="Regresar" aria-label="Regresar">
+                <i class="fas fa-arrow-left"></i>
+            </button>
+            <h3 class="text-light mb-0">{{selectedScout.scoutName}}</h3>
+        </div>
+        <div class="scroll-container">
+            <div style="min-width: 600px;">
+                <table class="row modern-table">
+                    <tr class="row">
+                        <th class="col col-2">#</th>
+                        <th class="col col-5">Jugador</th>
+                        <th class="col col-3">Equipo</th>
+                        <th class="col col-2">Categoria</th>
+                    </tr>
+                    <tr class="row clickable-row" *ngFor="let report of selectedScout.reports" (click)="selectReport(report)">
+                        <td class="col col-2">{{report.playerNumber}}</td>
+                        <td class="col col-5">{{report.playerName}}</td>
+                        <td class="col col-3">{{report.teamName}}</td>
+                        <td class="col col-2">{{report.category}}</td>
+                    </tr>
+                </table>
+            </div>
         </div>
     </div>
-</div>  
+
+</div>
+
+<!-- Level 3: the report this scout submitted for the selected player, laid out
+     like the evaluation detail modal in Estadisticas de Evaluacion. -->
+<div class="modal" tabindex="-1" role="dialog" [ngStyle]="{'display':displayStyle}" *ngIf="selectedReport">
+    <div class="modal-dialog modal-dialog-centered modal-xl modal-dialog-scrollable" role="document">
+        <div class="modal-content modern-player-modal">
+            <div class="modal-header dark-header">
+                <h5 class="modal-title">Detalle del Reporte</h5>
+                <button type="button" class="btn-close" (click)="closeReport()" aria-label="Close"></button>
+            </div>
+            <div class="modal-body modern-player-modal__body">
+                <div class="row g-3 align-items-stretch">
+                    <div class="col col-12 col-md-4">
+                        <div class="modern-player-modal__image-card">
+                            <img class="modern-player-modal__image" [src]="imageUrl" alt="Foto del jugador">
+                        </div>
+                    </div>
+
+                    <div class="col col-12 col-md-8">
+                        <div class="modern-player-modal__summary">
+                            <div class="detail-row">
+                                <div class="detail-label">Nombre</div>
+                                <div class="playerfield">({{selectedReport.playerNumber}}) {{selectedReport.playerName}}</div>
+                            </div>
+
+                            <div class="detail-row">
+                                <div class="detail-label">Scout</div>
+                                <div class="playerfield">{{selectedReport.scoutName}}</div>
+                            </div>
+
+                            <div class="detail-row">
+                                <div class="detail-label">Equipo</div>
+                                <div class="playerfield">{{selectedReport.teamName}} ({{selectedReport.category}})</div>
+                            </div>
+
+                            <div class="detail-row" *ngIf="reportGeneral">
+                                <div class="detail-label">Evaluacion General</div>
+                                <div class="playerfield">{{reportGeneral}}</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <br>
+
+                <div class="spinner-border" role="status" *ngIf="loadingReport">
+                    <span class="sr-only">Loading...</span>
+                </div>
+
+                <p *ngIf="!loadingReport && reportSections.length == 0">
+                    Este reporte no tiene datos registrados.
+                </p>
+
+                <div class="row g-3">
+                    <div *ngFor="let section of reportSections" class="col-12 score-block"
+                         [class.col-md-6]="!section.fullWidth">
+                        <div class="row">
+                            <div class="col-12"><b>{{section.title}}:</b></div>
+                        </div>
+                        <!-- Checkbox sections list only what the scout picked, so
+                             the option name is the value and fills the row. -->
+                        <div class="row myrow" *ngFor="let skill of section.skills">
+                            <ng-container *ngIf="section.valueOnly">
+                                <div class="col-12 playerfield">{{skill.value}}</div>
+                            </ng-container>
+                            <ng-container *ngIf="!section.valueOnly">
+                                <div class="col-10" [class.col-md-11]="section.fullWidth">{{skill.label}}</div>
+                                <div class="col-2 playerfield" [class.col-md-1]="section.fullWidth">{{skill.value}}</div>
+                            </ng-container>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer modern-player-modal__footer">
+                <button type="button" class="btn btn-outline-dark" (click)="closeReport()">
+                    Cerrar
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/angular-app/src/app/restricted-area/reports/reports.component.scss
+++ b/angular-app/src/app/restricted-area/reports/reports.component.scss
@@ -1,0 +1,14 @@
+@import "colors";
+@import "evaluation-modal";
+
+// Summary row at the bottom of the scouts table: same cells as a data row but
+// tinted and bold, so it reads as a total rather than a clickable entry.
+.total-row td{
+    background-color: darken($bg-color2, 8%);
+    font-weight: 700;
+}
+
+.modal-dialog {
+    color: $bg-color1;
+    background-color: transparent;
+}

--- a/angular-app/src/app/restricted-area/reports/reports.component.ts
+++ b/angular-app/src/app/restricted-area/reports/reports.component.ts
@@ -6,7 +6,8 @@ import { ReporteBuilder } from '../../Builders/reporte-builder';
 import { Role } from 'src/app/enum/Role';
 import { TOURNAMENT_YEAR } from 'src/app/aws-clients/constants';
 import { Scout } from 'src/app/interfaces/scout';
-import { ReportBasic } from 'src/app/interfaces/reporte';
+import { ReportBasic, ReportSectionView, ScoutReports } from 'src/app/interfaces/reporte';
+import { S3 } from 'src/app/aws-clients/s3';
 import { PlayerBuilder } from 'src/app/Builders/player-builder';
 import { Player } from 'src/app/interfaces/player';
 import { TeamBuilder } from 'src/app/Builders/team-builder';
@@ -39,12 +40,25 @@ export class ReportsComponent {
 
 
   @Input() ddb!: DynamoDb;
+  @Input() s3!: S3;
   loading = true;
   reports: ReportBasic[] = []
+  // One row per scout with the reports that scout submitted.
+  scoutReports: ScoutReports[] = []
   teamsMap: Map<string,string> = new Map<string, string>();
   playersMap: Map<string,Player> = new Map<string, Player>();
-  scoutsMap: Map<string,string> = new Map<string, string>();
+  // Keyed by scout id; holds the full record so the list can show contact info.
+  scoutsMap: Map<string,Scout> = new Map<string, Scout>();
 
+  // Drill-down state: pick a scout to see its players, then a player to open the
+  // report that scout submitted for them in a modal.
+  selectedScout: ScoutReports | undefined;
+  selectedReport: ReportBasic | undefined;
+  reportSections: ReportSectionView[] = [];
+  reportGeneral = "";
+  loadingReport = false;
+  displayStyle = "none";
+  imageUrl: string | ArrayBuffer | null | undefined = "assets/no-avatar.png";
 
 
   async ngOnInit() {
@@ -52,7 +66,7 @@ export class ReportsComponent {
     let scouts = await this.userBuilder.getAllScouts(this.ddb);
     scouts = scouts.filter(s => s.year === TOURNAMENT_YEAR);
     scouts.forEach(scout => {
-      this.scoutsMap.set(scout.id, scout.name);
+      this.scoutsMap.set(scout.id, scout);
     });
 
     this.reports = await this.reportBuilder.getAllReportsScoutPlayerMap(this.ddb)
@@ -68,16 +82,99 @@ export class ReportsComponent {
     });
 
     this.reports.forEach(report => {
-      console.log("report scout "+ report.scoutId + " reviewed "+report.playerId)
       let player = this.playersMap.get(report.playerId);
-      report.playerName = "(" + (player?.number ? player?.number : "#") + ") " + player?.name!
-      report.scoutName = this.scoutsMap.get(report.scoutId)!
+      report.playerNumber = player?.number ? player.number : "#"
+      report.playerName = player?.name ?? report.playerId
+      report.scoutName = this.scoutsMap.get(report.scoutId)?.name ?? report.scoutId
       report.teamName = this.teamsMap.get(player?.team!)!
     });
 
-    this.reports.sort((a, b) => a.scoutName.localeCompare(b.scoutName))
+    this.groupReportsByScout()
 
     this.loading = false;
+  }
+
+  // Collapse the flat report list into one entry per scout, each holding that
+  // scout's reports sorted by player name. Every registered scout gets a row —
+  // seeded from scoutsMap — so scouts who haven't submitted anything show up
+  // with a count of 0.
+  groupReportsByScout() {
+    let grouped: Map<string, ScoutReports> = new Map<string, ScoutReports>();
+
+    this.scoutsMap.forEach((scout, scoutId) => {
+      grouped.set(scoutId, {scoutId: scoutId, scoutName: scout.name, email: scout.email, phone: scout.phone, reports: []})
+    });
+
+    this.reports.forEach(report => {
+      let entry = grouped.get(report.scoutId)
+      if (entry == undefined) {
+        entry = {scoutId: report.scoutId, scoutName: report.scoutName, email: "", phone: "", reports: []}
+        grouped.set(report.scoutId, entry)
+      }
+      entry.reports.push(report)
+    });
+
+    this.scoutReports = Array.from(grouped.values())
+    this.scoutReports.forEach(scout => {
+      scout.reports.sort((a, b) => a.playerName.localeCompare(b.playerName))
+    })
+    // Most productive scouts first; ties fall back to name so the order is stable.
+    this.scoutReports.sort((a, b) =>
+      b.reports.length - a.reports.length || a.scoutName.localeCompare(b.scoutName))
+  }
+
+  get totalReports(): number {
+    return this.reports.length;
+  }
+
+  selectScout(scout: ScoutReports) {
+    if (scout.reports.length == 0) return;
+    this.selectedScout = scout;
+    this.closeReport();
+  }
+
+  backToScouts() {
+    this.selectedScout = undefined;
+    this.closeReport();
+  }
+
+  async selectReport(report: ReportBasic) {
+    this.selectedReport = report;
+    this.reportSections = [];
+    this.reportGeneral = "";
+    this.loadingReport = true;
+    this.displayStyle = "block";
+
+    this.loadPlayerPhoto(report.playerId);
+
+    let view = await this.reportBuilder.getScoutPlayerReport(this.ddb, report.scoutId, report.playerId)
+    this.reportSections = view.sections;
+    this.reportGeneral = view.general;
+    this.loadingReport = false;
+  }
+
+  // Show the player's photo in the modal, falling back to the default avatar.
+  loadPlayerPhoto(playerId: string) {
+    this.imageUrl = "assets/no-avatar.png";
+
+    let player = this.playersMap.get(playerId);
+    if (!player?.imageType || !this.s3) return;
+
+    this.s3.downloadFile(playerId).then(data => {
+      if (!data) return;
+      const blob = new Blob([data], {type: player!.imageType});
+      const reader = new FileReader();
+      reader.readAsDataURL(blob);
+      reader.onload = () => this.imageUrl = reader.result;
+    });
+  }
+
+  closeReport() {
+    this.selectedReport = undefined;
+    this.reportSections = [];
+    this.reportGeneral = "";
+    this.displayStyle = "none";
+    this.imageUrl = "assets/no-avatar.png";
   }
 
 }

--- a/angular-app/src/app/restricted-area/restricted-area.component.html
+++ b/angular-app/src/app/restricted-area/restricted-area.component.html
@@ -71,7 +71,7 @@
                         </div>
                         
                         <div *ngIf="listReportsView">
-                            <app-reports [ddb]="ddb"></app-reports>
+                            <app-reports [ddb]="ddb" [s3]="s3"></app-reports>
                         </div>
                         
                         <div *ngIf="listTeamsView">

--- a/angular-app/src/app/restricted-area/restricted-area.component.ts
+++ b/angular-app/src/app/restricted-area/restricted-area.component.ts
@@ -147,7 +147,7 @@ export class RestrictedAreaComponent {
           {value: "scouting", text: "Scouting"},
           {value: "listPlayers", text: "Jugadores Registrados"},
           {value: "viewUsers", text: "Usuarios Registrados"},
-          {value: "listReports", text: "Evaluaciones Enviadas"}
+          {value: "listReports", text: "Reportes"}
         ]);
       }
       if(this.isCoach){

--- a/angular-app/src/app/restricted-area/resultados-evaluacion/resultados-evaluacion.component.scss
+++ b/angular-app/src/app/restricted-area/resultados-evaluacion/resultados-evaluacion.component.scss
@@ -1,4 +1,5 @@
 @import "colors";
+@import "evaluation-modal";
 
 .mainpanel {
     display: flex;
@@ -8,94 +9,8 @@
     padding: 2%;
     background: linear-gradient(to bottom left, $bg-color1, $bg-color2);
 
-    -ms-flex: 1;  /* IE 10 */  
+    -ms-flex: 1;  /* IE 10 */
     flex: 1;
-}
-
-.modern-player-modal {
-    border: 1px solid $modal-surface-strong-border;
-    border-radius: 1rem;
-    overflow: hidden;
-    background: $bg-color2;
-    color: $bg-color1;
-    box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.28);
-}
-
-.modern-player-modal .modal-header.dark-header {
-    background: $bg-color1;
-    color: $header-color1;
-    border-bottom: 0;
-}
-
-.modern-player-modal__body {
-    background: linear-gradient(180deg, $modal-surface-gradient-start, $modal-surface-gradient-end);
-    padding: 1.25rem;
-}
-
-.modern-player-modal__image-card {
-    height: 100%;
-    min-height: 240px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: $modal-surface-muted;
-    border: 1px solid $modal-surface-border;
-    border-radius: 0.9rem;
-    padding: 1rem;
-}
-
-.modern-player-modal__image {
-    max-height: 220px;
-    max-width: 100%;
-    object-fit: contain;
-    border-radius: 0.75rem;
-}
-
-.modern-player-modal__summary {
-    display: flex;
-    flex-direction: column;
-    gap: 0.8rem;
-}
-
-.detail-row {
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-}
-
-.detail-label {
-    color: $bg-color1;
-    font-weight: 700;
-    font-size: 0.82rem;
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
-}
-
-.playerfield {
-    background: rgba($modal-surface-color, 0.98);
-    color: $bg-color1;
-    font-weight: 700;
-    padding: 0.6rem 0.8rem;
-    border-radius: 0.65rem;
-    border: 1px solid $modal-surface-strong-border;
-    box-shadow: inset 0 1px 0 rgba($modal-surface-color, 0.65);
-}
-
-.myrow {
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
-}
-
-.myrow div {
-  margin-top: 0.35rem;
-  margin-bottom: 0.35rem;
-}
-
-.score-block {
-    padding: 0.75rem;
-    background: rgba($bg-color1, 0.04);
-    border: 1px solid $modal-surface-border;
-    border-radius: 0.75rem;
 }
 
 .row {
@@ -114,9 +29,3 @@
     color: $bg-color1;
     background-color: transparent;
 }
-
-.modern-player-modal__footer {
-    background: $bg-color2;
-    border-top: 1px solid $modal-surface-border;
-}
-


### PR DESCRIPTION
The reports list showed one row per report, which made it hard to see who had submitted what. It now collapses to one row per scout, sorted by report count, with the scout's email and phone alongside the name and a tournament-wide total at the bottom. Every scout registered for the year gets a row, so scouts with nothing submitted show a count of 0.

Clicking a scout opens that scout's evaluated players (number, name, team, category); clicking a player opens the full report in a modal laid out like the evaluation detail modal in Estadisticas de Evaluacion. That shared modal styling moved into src/_evaluation-modal.scss so both views use it. Checkbox sections (posicion, estilo, nominacion) list only the options the scout picked instead of pairing each option with a "Si".

Also renames the menu entry from "Evaluaciones Enviadas" to "Reportes" and adds stylePreprocessorOptions to the karma target so component SCSS that imports "colors" compiles under `ng test`.