### PR TITLE
Add group standings tables to the public results page

### DIFF
--- a/angular-app/src/app/Builders/standing-builder.ts
+++ b/angular-app/src/app/Builders/standing-builder.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { ReportType, S3 } from '../aws-clients/s3';
+import { GroupStanding } from '../interfaces/standing';
+
+// readObject appends the extension, so this reads standings.json.
+const STANDINGS_FILE_NAME = 'standings'
+
+@Injectable({
+    providedIn: 'root'
+})
+export class StandingBuilder {
+
+    /**
+     * Read the group-stage standings the Retiarius CreateStandings workflow
+     * publishes for the current tournament year — every category and group in one
+     * file. Returns an empty list when the workflow hasn't run yet.
+     */
+    async getStandings(s3: S3): Promise<GroupStanding[]> {
+        let standingsString = await s3.readObject(STANDINGS_FILE_NAME, ReportType.STANDINGS)
+        if (!standingsString) return []
+
+        try {
+            let standings: GroupStanding[] = JSON.parse(standingsString)
+            return standings
+        } catch (err) {
+            console.error('Error parsing standings file', err)
+            return []
+        }
+    }
+}

--- a/angular-app/src/app/aws-clients/s3.ts
+++ b/angular-app/src/app/aws-clients/s3.ts
@@ -32,7 +32,10 @@ export { LIABILITY_WAIVER_PATH, LIABILITY_WAIVER_TEMPLATE_KEY };
 
 export enum ReportType {
     TOP_PLAYTERS = 'tops',
-    PLAYER_REPORT = 'reports'
+    PLAYER_REPORT = 'reports',
+    // Group-stage tables written by the Retiarius CreateStandings workflow, all
+    // categories and groups in a single standings.json.
+    STANDINGS = 'standings'
 }
 
 export { client };

--- a/angular-app/src/app/interfaces/standing.ts
+++ b/angular-app/src/app/interfaces/standing.ts
@@ -1,0 +1,24 @@
+// Group-stage standings as computed by the Retiarius CreateStandings workflow
+// and published to S3 as a single standings.json. These interfaces mirror that
+// file's shape, so any change here has to match the workflow's output.
+
+export interface StandingRow {
+    // 1-based standing. Repeated across teams whose standing nothing settles —
+    // same record, no game between them, same point differential — so positions
+    // can skip (1, 2, 2, 4).
+    position: number
+    teamId: string
+    teamName: string
+    played: number
+    won: number
+    lost: number
+    pointsFor: number
+    pointsAgainst: number
+    pointDifferential: number
+}
+
+export interface GroupStanding {
+    category: string
+    group: string
+    standings: StandingRow[]
+}

--- a/angular-app/src/app/results/standings/standings.component.html
+++ b/angular-app/src/app/results/standings/standings.component.html
@@ -28,50 +28,129 @@
             </div>
         </div>
 
-        <h2 *ngIf="!loading && standings.length === 0" class="text-center">
+        <h2 *ngIf="!loading && standings.length === 0 && groupStandings.length === 0" class="text-center">
             Próximamente, estad atentos.
         </h2>
 
-        <!-- One cross table per group: columns and rows are the same team list,
-             so the diagonal is the team against itself and is blacked out. -->
-        <div class="col col-12 standings-group" *ngFor="let groupStandings of standings">
-            <div class="scroll-container">
-                <table class="standings-table">
-                    <!-- Every cell's content is wrapped in .standings-cell, a fixed
-                         two-line box, so all rows end up exactly the same height. -->
-                    <thead>
-                        <tr>
-                            <th class="standings-table__corner">
-                                <div class="standings-cell"><span class="standings-cell__text">{{groupStandings.group}}</span></div>
-                            </th>
-                            <th *ngFor="let team of groupStandings.teams">
-                                <div class="standings-cell"><span class="standings-cell__text">{{team.name}}</span></div>
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr *ngFor="let rowTeam of groupStandings.rowTeams">
-                            <th class="standings-table__row-header">
-                                <div class="standings-cell"><span class="standings-cell__text">{{rowTeam.name}}</span></div>
-                            </th>
-                            <ng-container *ngFor="let columnTeam of groupStandings.teams">
-                                <td *ngIf="rowTeam.id === columnTeam.id" class="standings-table__self">
-                                    <div class="standings-cell"></div>
-                                </td>
-                                <td *ngIf="rowTeam.id !== columnTeam.id">
-                                    <div class="standings-cell">
-                                        <span class="standings-cell__text standings-result"
-                                              *ngIf="groupStandings.results[rowTeam.id][columnTeam.id] as cell"
-                                              [class.standings-result--win]="cell.outcome === 'G'"
-                                              [class.standings-result--loss]="cell.outcome === 'P'">
-                                            {{cell.outcome}} {{cell.teamPoints}} - {{cell.opponentPoints}}
-                                        </span>
-                                    </div>
-                                </td>
-                            </ng-container>
-                        </tr>
-                    </tbody>
-                </table>
+        <!-- Collapsible sections, same accordion cards the partidos page uses for
+             "Fase de Grupos". Both start expanded. -->
+        <div class="col col-12 accordion accordion-flush modern-accordion" *ngIf="standings.length > 0">
+            <div class="accordion-item">
+                <h2 class="accordion-header">
+                    <button class="accordion-button" type="button" data-bs-toggle="collapse"
+                            data-bs-target="#flush-collapseResults" aria-expanded="true"
+                            aria-controls="flush-collapseResults">
+                        Resultados
+                    </button>
+                </h2>
+                <div id="flush-collapseResults" class="accordion-collapse collapse show">
+                    <div class="accordion-body">
+                        <!-- One cross table per group: columns and rows are the same team
+                             list, so the diagonal is the team against itself and is
+                             blacked out. -->
+                        <div class="standings-group" *ngFor="let groupStandings of standings">
+                            <div class="scroll-container">
+                                <table class="standings-table">
+                                    <!-- Every cell's content is wrapped in .standings-cell, a
+                                         fixed two-line box, so all rows end up exactly the
+                                         same height. -->
+                                    <thead>
+                                        <tr>
+                                            <th class="standings-table__corner">
+                                                <div class="standings-cell"><span class="standings-cell__text">{{groupStandings.group}}</span></div>
+                                            </th>
+                                            <th *ngFor="let team of groupStandings.teams">
+                                                <div class="standings-cell"><span class="standings-cell__text">{{team.name}}</span></div>
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr *ngFor="let rowTeam of groupStandings.rowTeams">
+                                            <th class="standings-table__row-header">
+                                                <div class="standings-cell"><span class="standings-cell__text">{{rowTeam.name}}</span></div>
+                                            </th>
+                                            <ng-container *ngFor="let columnTeam of groupStandings.teams">
+                                                <td *ngIf="rowTeam.id === columnTeam.id" class="standings-table__self">
+                                                    <div class="standings-cell"></div>
+                                                </td>
+                                                <td *ngIf="rowTeam.id !== columnTeam.id">
+                                                    <div class="standings-cell">
+                                                        <span class="standings-cell__text standings-result"
+                                                              *ngIf="groupStandings.results[rowTeam.id][columnTeam.id] as cell"
+                                                              [class.standings-result--win]="cell.outcome === 'G'"
+                                                              [class.standings-result--loss]="cell.outcome === 'P'">
+                                                            {{cell.outcome}} {{cell.teamPoints}} - {{cell.opponentPoints}}
+                                                        </span>
+                                                    </div>
+                                                </td>
+                                            </ng-container>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Position tables, published to S3 by the CreateStandings workflow.
+             Absent until the workflow has run for the year, so the whole section
+             only appears once there's something to show. -->
+        <div class="col col-12 accordion accordion-flush modern-accordion" *ngIf="groupStandings.length > 0">
+            <div class="accordion-item">
+                <h2 class="accordion-header">
+                    <button class="accordion-button" type="button" data-bs-toggle="collapse"
+                            data-bs-target="#flush-collapsePositions" aria-expanded="true"
+                            aria-controls="flush-collapsePositions">
+                        Posiciones
+                    </button>
+                </h2>
+                <div id="flush-collapsePositions" class="accordion-collapse collapse show">
+                    <div class="accordion-body">
+                        <div class="standings-group" *ngFor="let group of groupStandings">
+                            <h3 class="text-center standings-positions__group">{{group.group}}</h3>
+                            <div class="scroll-container">
+                                <table class="positions-table">
+                                    <thead>
+                                        <tr>
+                                            <th class="positions-table__position">#</th>
+                                            <th class="positions-table__team">Equipo</th>
+                                            <th>JJ</th>
+                                            <th>G</th>
+                                            <th>P</th>
+                                            <th>PF</th>
+                                            <th>PC</th>
+                                            <th>DIF</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <!-- With a team filter on, every row stays so the
+                                             position keeps its context; the picked team is
+                                             highlighted. -->
+                                        <tr *ngFor="let row of group.standings"
+                                            [class.positions-table__row--selected]="row.teamId === selectedTeamId">
+                                            <td class="positions-table__position">{{row.position}}</td>
+                                            <td class="positions-table__team">{{row.teamName}}</td>
+                                            <td>{{row.played}}</td>
+                                            <td class="positions-table__won">{{row.won}}</td>
+                                            <td>{{row.lost}}</td>
+                                            <td>{{row.pointsFor}}</td>
+                                            <td>{{row.pointsAgainst}}</td>
+                                            <td>
+                                                <span class="positions-differential"
+                                                      [class.positions-differential--positive]="row.pointDifferential > 0"
+                                                      [class.positions-differential--negative]="row.pointDifferential < 0">
+                                                    {{row.pointDifferential > 0 ? '+' : ''}}{{row.pointDifferential}}
+                                                </span>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/angular-app/src/app/results/standings/standings.component.scss
+++ b/angular-app/src/app/results/standings/standings.component.scss
@@ -59,6 +59,11 @@
 
 .standings-group {
     margin-bottom: 2.5rem;
+
+    // The accordion body already provides the padding below the last table.
+    &:last-child {
+        margin-bottom: 0;
+    }
 }
 
 // Fixed column widths. The first column is sized so team names wrap into at most
@@ -72,9 +77,13 @@ $result-column-width: 10.5rem;
 $cell-line-height: 1.3rem;
 $cell-lines: 2;
 
+// Shared modern-table treatment: rounded outer corners, no cell grid, hairline
+// dividers instead of borders.
+$table-radius: 0.75rem;
+
 // Cross table: the top-left corner cell carries the group name, the first row
 // and first column are the team headers, and the diagonal (team vs itself) is
-// blacked out.
+// filled in.
 .standings-table {
     // `table-layout: auto` with matching min/max widths per cell, rather than
     // `fixed` + `width`: under `fixed` the table sizes to its container first and
@@ -86,14 +95,32 @@ $cell-lines: 2;
     border-collapse: separate;
     border-spacing: 0;
     color: $bg-color1;
+    // Corners are rounded per cell rather than by clipping the table: `overflow`
+    // on the table would make it the scroll container for the sticky row headers
+    // below, pinning them to the table instead of to .scroll-container.
+    border-radius: $table-radius;
 
     th, td {
         min-width: $result-column-width;
         max-width: $result-column-width;
-        padding: 0.4rem 0.5rem;
-        border: 1px solid $bg-color1;
+        padding: 0.55rem 0.65rem;
         vertical-align: middle;
+        // Hairlines only, so the data reads as rows and columns rather than as a
+        // grid of boxes. The last of each is dropped below so the rounded corners
+        // aren't cut by a stray line.
+        border-right: 1px solid $divider-color;
+        border-bottom: 1px solid $divider-color;
     }
+
+    tr > :last-child { border-right: 0; }
+    tbody tr:last-child > * { border-bottom: 0; }
+
+    // Rounded outer corners, applied to the corner cells since the table itself
+    // can't clip them.
+    thead tr:first-child th:first-child { border-top-left-radius: $table-radius; }
+    thead tr:first-child th:last-child { border-top-right-radius: $table-radius; }
+    tbody tr:last-child > :first-child { border-bottom-left-radius: $table-radius; }
+    tbody tr:last-child > :last-child { border-bottom-right-radius: $table-radius; }
 
     // Column headers: the opponents. The corner is excluded so its own, darker
     // treatment below wins — view-encapsulation attributes would otherwise make
@@ -102,17 +129,29 @@ $cell-lines: 2;
         background-color: $header-color1;
         color: $bg-color1;
         font-weight: 700;
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
         text-align: center;
+        // Against the yellow header a grey hairline muddies the fill; a translucent
+        // dark tint keeps the columns separated in the same tone.
+        border-right-color: rgba($bg-color1, 0.18);
+        border-bottom-color: rgba($bg-color1, 0.18);
     }
 
     // Row headers: the team the results are read from. Wider than the result
-    // columns, since these hold the team names.
+    // columns, since these hold the team names. Pinned to the left so the team
+    // stays visible while scrolling across a wide group.
     .standings-table__row-header {
         min-width: $row-header-width;
         max-width: $row-header-width;
+        position: sticky;
+        left: 0;
+        z-index: 1;
         background-color: $header-color1;
         color: $bg-color1;
         font-weight: 700;
+        border-right-color: rgba($bg-color1, 0.18);
 
         .standings-cell {
             justify-content: flex-end;
@@ -125,9 +164,14 @@ $cell-lines: 2;
 
     // Group name sits in the empty corner above the row headers. Dark panel with
     // the brand yellow on top so it reads as the table's title, not as a team.
+    // Pinned with the row headers it sits above, and one level higher so it stays
+    // on top of them.
     th.standings-table__corner {
         min-width: $row-header-width;
         max-width: $row-header-width;
+        position: sticky;
+        left: 0;
+        z-index: 2;
         background-color: $bg-color1;
         color: $header-color1;
         font-weight: 800;
@@ -135,6 +179,8 @@ $cell-lines: 2;
         text-transform: uppercase;
         letter-spacing: 0.04em;
         text-align: center;
+        border-right-color: rgba($header-color1, 0.25);
+        border-bottom-color: rgba($header-color1, 0.25);
     }
 
     td {
@@ -142,9 +188,24 @@ $cell-lines: 2;
         text-align: center;
     }
 
-    // A team never plays itself, so the diagonal is filled in solid.
+    // A team never plays itself, so the diagonal is filled in. Diagonal hatching
+    // rather than a solid block: it reads as "not applicable" instead of as an
+    // unplayed game, which is what the empty cells mean.
     .standings-table__self {
-        background-color: $bg-color1;
+        background-color: darken($bg-color2, 4%);
+        background-image: repeating-linear-gradient(
+            45deg,
+            transparent,
+            transparent 5px,
+            rgba($bg-color1, 0.08) 5px,
+            rgba($bg-color1, 0.08) 10px
+        );
+    }
+
+    // Reading across one team's results is the main use of this table, so the row
+    // under the cursor is tinted.
+    tbody tr:hover td:not(.standings-table__self) {
+        background-color: darken($bg-color2, 5%);
     }
 
     // Every cell's content lives in this box, fixed at two lines tall so all rows
@@ -169,9 +230,141 @@ $cell-lines: 2;
     }
 }
 
+// Each result is a pill, so a row of them scans as won/lost at a glance without
+// having to read the G/P letter on every cell.
 .standings-result {
-    font-weight: 600;
+    display: inline-block;
+    padding: 0.15rem 0.55rem;
+    border-radius: 999px;
+    font-weight: 700;
+    font-size: 0.85rem;
+    font-variant-numeric: tabular-nums;
+    background-color: rgba($bg-color1, 0.08);
 
-    &--win { color: darken($text-color1, 20%); }
-    &--loss { color: $text-color2; }
+    &--win {
+        color: darken($text-color1, 32%);
+        background-color: rgba($text-color1, 0.35);
+    }
+
+    &--loss {
+        color: darken($text-color2, 25%);
+        background-color: rgba($text-color2, 0.22);
+    }
+}
+
+// Position tables below the cross tables: one row per team, ordered by the
+// standing the CreateStandings workflow computed.
+
+// Sits on the accordion body's light panel, so the dark base colour rather than
+// the brand yellow the section headings use elsewhere.
+.standings-positions__group {
+    color: $bg-color1;
+    font-weight: 700;
+    margin-bottom: 0.75rem;
+}
+
+.positions-table {
+    // Same reasoning as .standings-table: pinned column widths that overflow into
+    // .scroll-container rather than shrinking on a narrow screen.
+    table-layout: auto;
+    width: auto;
+    border-collapse: separate;
+    border-spacing: 0;
+    color: $bg-color1;
+    border-radius: $table-radius;
+    // This table is narrow enough to fit the panel, so center it rather than
+    // leaving it against the left edge. Auto margins (not `justify-content` on the
+    // container) because they collapse to 0 when the table does overflow, instead
+    // of pushing its first columns out of reach of the horizontal scroll.
+    margin-left: auto;
+    margin-right: auto;
+
+    th, td {
+        min-width: 3.5rem;
+        padding: 0.55rem 0.65rem;
+        text-align: center;
+        vertical-align: middle;
+        line-height: $cell-line-height;
+        // Row dividers only — the stat columns are narrow and evenly spaced, so
+        // vertical lines add noise without helping.
+        border-bottom: 1px solid $divider-color;
+        // Stats line up column-wise even with mixed digit counts.
+        font-variant-numeric: tabular-nums;
+    }
+
+    tbody tr:last-child > * { border-bottom: 0; }
+
+    thead th {
+        background-color: $header-color1;
+        color: $bg-color1;
+        font-weight: 700;
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        border-bottom-color: rgba($bg-color1, 0.18);
+    }
+
+    thead th:first-child { border-top-left-radius: $table-radius; }
+    thead th:last-child { border-top-right-radius: $table-radius; }
+    tbody tr:last-child td:first-child { border-bottom-left-radius: $table-radius; }
+    tbody tr:last-child td:last-child { border-bottom-right-radius: $table-radius; }
+
+    td {
+        background-color: $bg-color2;
+    }
+
+    tbody tr:hover td {
+        background-color: darken($bg-color2, 5%);
+    }
+
+    // The standing itself, so it carries the most weight in the row.
+    .positions-table__position {
+        min-width: 2.75rem;
+        max-width: 2.75rem;
+        font-weight: 800;
+        font-size: 1.05rem;
+    }
+
+    // Holds the team names, so it gets the same width as the cross table's row
+    // headers and is the only left-aligned, wrapping column.
+    .positions-table__team {
+        min-width: $row-header-width;
+        max-width: $row-header-width;
+        text-align: left;
+        font-weight: 600;
+        // Set explicitly because .scroll-container sets nowrap on its subtree.
+        white-space: normal;
+        overflow-wrap: break-word;
+    }
+
+    // Games won is what the standing is built on, so it's the one stat set apart
+    // from the rest.
+    .positions-table__won {
+        font-weight: 700;
+    }
+
+    // The team picked in the filter, so its row is findable at a glance. A left
+    // marker plus a tint rather than the full yellow fill, which was loud enough
+    // to read as the header row.
+    .positions-table__row--selected td {
+        background-color: rgba($header-color1, 0.3);
+        font-weight: 700;
+    }
+
+    .positions-table__row--selected td:first-child {
+        box-shadow: inset 3px 0 0 $header-color1;
+    }
+
+    tbody tr.positions-table__row--selected:hover td {
+        background-color: rgba($header-color1, 0.4);
+    }
+}
+
+// Point differential: coloured text, not a pill — it sits in a stat column next
+// to plain numbers, so a filled background would pull the eye off the standing.
+.positions-differential {
+    font-weight: 700;
+
+    &--positive { color: darken($text-color1, 32%); }
+    &--negative { color: darken($text-color2, 20%); }
 }

--- a/angular-app/src/app/results/standings/standings.component.ts
+++ b/angular-app/src/app/results/standings/standings.component.ts
@@ -3,9 +3,13 @@ import { FormControl } from '@angular/forms';
 import { Match } from '../../interfaces/match';
 import { Category, MatchTeam } from '../../interfaces/team';
 import { MatchBuilder } from '../../Builders/match-builder';
+import { StandingBuilder } from '../../Builders/standing-builder';
 import { DynamoDb } from '../../aws-clients/dynamodb';
+import { S3 } from '../../aws-clients/s3';
+import { GroupStanding } from '../../interfaces/standing';
 import { COGNITO_UNAUTHENTICATED_CREDENTIALS, TOURNAMENT_YEAR, REGION } from '../../aws-clients/constants'
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { S3Client } from '@aws-sdk/client-s3';
 
 // One result as seen from the row team's point of view: "G 44 - 38" means the
 // row team won 44 to 38. Cells stay undefined when the pairing hasn't been
@@ -39,6 +43,10 @@ export class StandingsComponent implements OnInit {
     credentials: COGNITO_UNAUTHENTICATED_CREDENTIALS
   });
   ddb: DynamoDb = new DynamoDb(this.ddbClient);
+  s3: S3 = new S3(new S3Client({
+    region: REGION,
+    credentials: COGNITO_UNAUTHENTICATED_CREDENTIALS
+  }));
 
   loading = true;
 
@@ -65,9 +73,19 @@ export class StandingsComponent implements OnInit {
   // filter applied. Kept in sync by applyFilters().
   standings: GroupStandings[] = [];
 
+  // Position tables published to S3 by the Retiarius CreateStandings workflow,
+  // grouped by category. Shown below the cross tables.
+  groupStandingsByCategory: Partial<Record<Category, GroupStanding[]>> = {};
+
+  // The selected category's position tables, with the team filter applied.
+  groupStandings: GroupStanding[] = [];
+
   selectedYear = "";
 
-  constructor(private matchBuilder: MatchBuilder) {
+  constructor(
+    private matchBuilder: MatchBuilder,
+    private standingBuilder: StandingBuilder
+  ) {
   }
 
   async ngOnInit() {
@@ -84,12 +102,14 @@ export class StandingsComponent implements OnInit {
   selectTeam() {
     this.selectedTeamId = this.team.value ?? "";
     this.applyFilters();
+    this.applyStandingsFilters();
   }
 
   clearTeam() {
     this.selectedTeamId = "";
     this.team.setValue("");
     this.applyFilters();
+    this.applyStandingsFilters();
   }
 
   // Teams of the selected category, for the team dropdown.
@@ -119,14 +139,34 @@ export class StandingsComponent implements OnInit {
       }));
   }
 
+  // Same shape as applyFilters(), for the position tables. Unlike the cross
+  // table, the team filter keeps every row of the group: a position only means
+  // something next to the teams it's measured against. The team's own row is
+  // highlighted instead.
+  private applyStandingsFilters() {
+    const groupStandings = this.groupStandingsByCategory[this.selectedCategory] ?? [];
+
+    if (!this.selectedTeamId) {
+      this.groupStandings = groupStandings;
+      return;
+    }
+
+    this.groupStandings = groupStandings
+      .filter(group => group.standings.some(row => row.teamId === this.selectedTeamId));
+  }
+
   async loadMatches(year: string) {
     this.loading = true;
     this.selectedYear = year;
     this.standingsByCategory = {};
     this.teamsByCategory = {};
+    this.groupStandingsByCategory = {};
     this.clearTeam();
 
-    const allMatches = await this.matchBuilder.getListOfMatch(this.ddb, year);
+    const [allMatches, publishedStandings] = await Promise.all([
+      this.matchBuilder.getListOfMatch(this.ddb, year),
+      this.standingBuilder.getStandings(this.s3)
+    ]);
 
     const groupMatches = allMatches.filter(match => this.groups.includes(match.juego));
 
@@ -136,12 +176,27 @@ export class StandingsComponent implements OnInit {
       );
       this.standingsByCategory[category] = standings;
       this.teamsByCategory[category] = this.collectFilterTeams(standings);
+      this.groupStandingsByCategory[category] = this.orderGroupStandings(
+        publishedStandings.filter(group => group.category === category)
+      );
     });
 
     // clearTeam() above ran before the tables existed, so pick them up now.
     this.applyFilters();
+    this.applyStandingsFilters();
 
     this.loading = false;
+  }
+
+  // The file lists groups in whatever order the workflow emitted them; line them
+  // up with the cross tables above. Groups the workflow named but this page
+  // doesn't know about go last, in file order.
+  private orderGroupStandings(groupStandings: GroupStanding[]): GroupStanding[] {
+    return [...groupStandings].sort((a, b) => {
+      const aIndex = this.groups.indexOf(a.group);
+      const bIndex = this.groups.indexOf(b.group);
+      return (aIndex < 0 ? this.groups.length : aIndex) - (bIndex < 0 ? this.groups.length : bIndex);
+    });
   }
 
   // Flattens the per-group team lists into one alphabetical list for the team


### PR DESCRIPTION
Brings the standings file the Retiarius CreateStandings workflow publishes into the Tabla de Resultados page, below the existing cross tables. The workflow writes every category/group table as a single standings.json; StandingBuilder reads it and the page renders one position table per group with games played/won/lost, points for/against and differential.

StandingRow and GroupStanding mirror the workflow's interfaces verbatim, and ReportType.STANDINGS matches the enum value it writes with, so readObject already resolves the right key. The section is hidden until the workflow has run for the year, so the page is unchanged without it.

Unlike the cross table, the team filter keeps every row of the group and highlights the picked team instead of narrowing to one row — a position only means something next to the teams it's ranked against.

Both sections are now collapsible accordion cards, matching the "Fase de Grupos" format on the partidos page, and the tables follow the app's modern-table look: rounded corners and hairline dividers instead of a 1px grid on every cell, sticky team-name column on the cross table, result pills, and hatching rather than a solid block on the diagonal.