### PR TITLE
Add gym live feed links and modernize gym admin view

### DIFF
--- a/angular-app/src/app/Builders/gym-builder.ts
+++ b/angular-app/src/app/Builders/gym-builder.ts
@@ -13,17 +13,42 @@ export class GymBuilder {
     constructor(
     ) {}
 
-    async createGym(ddb: DynamoDb, id: string, name: string, address: string, place_id: string) {
+    async createGym(ddb: DynamoDb, id: string, name: string, address: string, place_id: string, live_feed?: string) {
         let gymRecord: Record<string, AttributeValue> = {}
         gymRecord[PK_KEY] = {S: `gym.${id}`};
         gymRecord[SK_KEY] = {S: `gym.data`};
         gymRecord["name"] = {S: `${name}`};
         gymRecord["address"] = {S: `${address}`};
         gymRecord["place_id"] = {S: `${place_id}`};
+        gymRecord["live_feed"] = {S: `${live_feed ?? ''}`};
         gymRecord[CY_KEY] = {S: TOURNAMENT_YEAR};
         await ddb.putItem(gymRecord);
     }
-    
+
+    // Updates an existing gym in place. The id is part of the partition key, so
+    // it identifies the record and cannot itself be changed here.
+    async updateGym(ddb: DynamoDb, gym: Gym) {
+        let key = {
+            [PK_KEY]: {S: `gym.${gym.id}`},
+            [SK_KEY]: {S: `gym.data`}
+        };
+        let updateExpression = 'SET #name = :name, #address = :address, #place = :place, #feed = :feed';
+        let expressionAttributeNames: Record<string, string> = {
+            '#name': 'name',
+            '#address': 'address',
+            '#place': 'place_id',
+            '#feed': 'live_feed',
+        };
+        let expressionAttributeValues: Record<string, AttributeValue> = {
+            ':name': {S: `${gym.name}`},
+            ':address': {S: `${gym.address ?? ''}`},
+            ':place': {S: `${gym.place_id ?? ''}`},
+            ':feed': {S: `${gym.live_feed ?? ''}`},
+        };
+
+        await ddb.updateItem(key, updateExpression, expressionAttributeNames, expressionAttributeValues);
+    }
+
     async getListOfGyms(ddb: DynamoDb, year?: string|undefined): Promise<Gym[]> {
         console.debug("year:", year)
         var gyms: Gym[] = []
@@ -48,7 +73,9 @@ export class GymBuilder {
             id: item[PK_KEY].S!.split('.')[1],
             name: item['name'].S!,
             address: item['address'].S,
-            place_id: item['place_id'].S
+            place_id: item['place_id'].S,
+            // Gyms registered before live feeds existed have no live_feed attribute.
+            live_feed: item['live_feed']?.S
         }
     }
 
@@ -57,7 +84,8 @@ export class GymBuilder {
             id: "",
             name: "",
             address: "",
-            place_id: ""
+            place_id: "",
+            live_feed: ""
         }
     }
 }

--- a/angular-app/src/app/interfaces/gym.ts
+++ b/angular-app/src/app/interfaces/gym.ts
@@ -4,4 +4,5 @@ export interface Gym {
     name: string  
     address?: string | undefined
     place_id?: string | undefined
+    live_feed?: string | undefined
 }

--- a/angular-app/src/app/restricted-area/add-gym/add-gym.component.html
+++ b/angular-app/src/app/restricted-area/add-gym/add-gym.component.html
@@ -1,55 +1,100 @@
-<div class="mainpanel">
-    <!-- New gym form: fields grouped in a filter-bar block, two per row,
-         with the yellow floppy-disk save button used elsewhere in the app. -->
-    <form class="filter-bar mb-3" [formGroup]="gymForm" (ngSubmit)="onSubmit()">
-        <div class="row g-2 justify-content-center">
-            <div class="col-12 col-md-6">
-                <label for="id" class="form-label text-light small mb-1">ID</label>
-                <input type="text" class="form-control" id="id" name="id" formControlName="id">
-            </div>
-            <div class="col-12 col-md-6">
-                <label for="name" class="form-label text-light small mb-1">Nombre</label>
-                <input type="text" class="form-control" id="name" name="name" formControlName="name">
-            </div>
-        </div>
-        <div class="row g-2 mt-1 justify-content-center">
-            <div class="col-12 col-md-6">
-                <label for="address" class="form-label text-light small mb-1">Dirección</label>
-                <input type="text" class="form-control" id="address" name="address" formControlName="address">
-            </div>
-            <div class="col-12 col-md-6">
-                <label for="place_id" class="form-label text-light small mb-1">Place ID</label>
-                <input type="text" class="form-control" id="place_id" name="place_id" formControlName="place_id">
-            </div>
-        </div>
-        <div class="row mt-2">
-            <div class="col-12 text-center">
-                <button type="submit" class="btn btn-warning btn-floating" title="Guardar" [disabled]="!gymForm.valid">
-                    <i class="fas fa-floppy-disk"></i>
-                </button>
-            </div>
-        </div>
-    </form>
+<h2 class="text-center mb-3">
+    Gimnasios
+</h2>
+
+<div class="spinner-border text-light" role="status" *ngIf="isLoading">
+    <span class="sr-only">Loading...</span>
+</div>
+
+<div class="mainpanel" *ngIf="!isLoading">
+    <!-- Registering a gym happens in the modal below, same as adding a player. -->
+    <div class="d-flex justify-content-end mb-3">
+        <button type="button" (click)="addGym()" class="btn btn-dark btn-floating"
+                title="Registrar Nuevo Gimnasio" aria-label="Registrar Nuevo Gimnasio">
+            <i class="fas fa-plus"></i>
+        </button>
+    </div>
 
     <div class="scroll-container">
-        <table *ngIf="!isLoading" class="modern-table" style="min-width: 100%;">
+        <table class="modern-table" style="min-width: 100%;">
             <tr>
                 <th> <a [routerLink]="">ID</a></th>
                 <th> <a [routerLink]="">Nombre</a></th>
                 <th> <a [routerLink]="">Dirección</a></th>
+                <!-- Flags at a glance which gyms have a transmission link. -->
+                <th> <a [routerLink]="">Transmisión</a></th>
             </tr>
-            <tr *ngFor="let gym of gyms">
+            <!-- Clicking a row opens it in the editor. -->
+            <tr class="clickable-row" *ngFor="let gym of gyms" [routerLink]="" (click)="edit(gym)">
                 <td>{{gym.id}}</td>
-                <td>{{gym.name}}</td>
-                <td><a href="https://www.google.com/maps/search/?api=1&query_place_id={{gym.place_id}}&query={{gym.address}}">{{gym.address}}</a></td>
+                <td><u>{{gym.name}}</u></td>
+                <td>{{gym.address}}</td>
+                <td>
+                    <!-- Opens the transmission itself; stops the click from also
+                         opening the row's editor. -->
+                    <a *ngIf="gym.live_feed" [href]="gym.live_feed" target="_blank" rel="noopener"
+                       (click)="$event.stopPropagation()"
+                       title="Ver Transmisión" aria-label="Ver Transmisión">
+                        <i class="fas fa-video"></i>
+                    </a>
+                </td>
             </tr>
         </table>
     </div>
 </div>
 
+<!--Gym editor modal: doubles as the new-gym form, in which case the id is editable-->
+<div class="modal"
+  tabindex="-1"
+  role="dialog"
+  [ngStyle]="{'display':displayGymForm}">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header dark-header">
+        <h5 class="modal-title">{{ editingGym ? editingGym.name : 'Nuevo Gimnasio' }}</h5>
+        <button type="button" class="btn-close" (click)="closeGymForm()" aria-label="Close">
+        </button>
+      </div>
+      <div class="modal-body">
+        <form [formGroup]="gymForm">
+            <div class="row g-2">
+                <div class="col-12 col-md-6">
+                    <label for="id" class="form-label small mb-1">ID</label>
+                    <!-- The id is the record's key, so it can only be set at creation. -->
+                    <input type="text" class="form-control" id="id" name="id" formControlName="id" [readonly]="!!editingGym">
+                </div>
+                <div class="col-12 col-md-6">
+                    <label for="name" class="form-label small mb-1">Nombre</label>
+                    <input type="text" class="form-control" id="name" name="name" formControlName="name">
+                </div>
+            </div>
+            <div class="row g-2 mt-1">
+                <div class="col-12 col-md-6">
+                    <label for="address" class="form-label small mb-1">Dirección</label>
+                    <input type="text" class="form-control" id="address" name="address" formControlName="address">
+                </div>
+                <div class="col-12 col-md-6">
+                    <label for="place_id" class="form-label small mb-1">Place ID</label>
+                    <input type="text" class="form-control" id="place_id" name="place_id" formControlName="place_id">
+                </div>
+            </div>
+            <div class="row g-2 mt-1">
+                <div class="col-12">
+                    <label for="live_feed" class="form-label small mb-1">Transmisión en Vivo (URL)</label>
+                    <input type="text" class="form-control" id="live_feed" name="live_feed" formControlName="live_feed">
+                </div>
+            </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-danger" (click)="onSubmit()" [disabled]="!gymForm.valid">
+          Confirmar
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
 
-
-    
 <div
 class="modal"
 tabindex="-1"
@@ -62,7 +107,7 @@ role="dialog"
 
     </div>
     <div class="modal-footer">
-      <button type="button" class="btn btn-danger" 
+      <button type="button" class="btn btn-danger"
               (click)="closePopup()">
         Cerrar
       </button>

--- a/angular-app/src/app/restricted-area/add-gym/add-gym.component.ts
+++ b/angular-app/src/app/restricted-area/add-gym/add-gym.component.ts
@@ -24,16 +24,23 @@ export class AddGymComponent implements OnInit {
   }
 
   gymForm = this.fb.group({
-    id: null,
-    name: null,
-    address: null,
-    place_id: null
+    id: [''],
+    name: [''],
+    address: [''],
+    place_id: [''],
+    live_feed: ['']
   });
 
   isLoading = true;
   gyms : Gym[] = [];
   displayStyle = "none";
   popUpMsg = "";
+
+  // The form lives in a modal that serves both registering a new gym and editing
+  // an existing one. editingGym is non-null only in the latter case, where the id
+  // is fixed since it's part of the key.
+  displayGymForm = "none";
+  editingGym: Gym | null = null;
 
   async loadGyms() {
     this.gyms = []
@@ -46,15 +53,21 @@ export class AddGymComponent implements OnInit {
   }
 
   async onSubmit(){
+    if(this.editingGym) {
+      await this.saveEdit();
+      return;
+    }
+
     try {
       if(this.gyms.find(g => g.id == this.gymForm.value.id!)){
         throw "Gym id already exists!"
       }
-      await this.gymBuilder.createGym(this.ddb, this.gymForm.value.id!, this.gymForm.value.name!, this.gymForm.value.address!, this.gymForm.value.place_id!)
+      await this.gymBuilder.createGym(this.ddb, this.gymForm.value.id!, this.gymForm.value.name!, this.gymForm.value.address!, this.gymForm.value.place_id!, this.gymForm.value.live_feed ?? undefined)
       console.warn ('Saved sucessfully!')
+      this.closeGymForm();
+      await this.loadGyms();
       this.popUpMsg = "Gimnasio Registrado!";
       this.openPopup();
-      this.gymForm.reset();
 
     } catch (err) {
       console.error("Error creating gym")
@@ -63,7 +76,52 @@ export class AddGymComponent implements OnInit {
     }
   }
 
+  // Opens the modal with an empty form to register a new gym.
+  addGym() {
+    this.editingGym = null;
+    this.gymForm.reset();
+    this.displayGymForm = "block";
+  }
 
+  // Opens the modal with this gym's values loaded, so its fields become editable.
+  edit(gym: Gym) {
+    this.editingGym = gym;
+    this.gymForm.patchValue({
+      id: gym.id,
+      name: gym.name,
+      address: gym.address ?? '',
+      place_id: gym.place_id ?? '',
+      live_feed: gym.live_feed ?? ''
+    });
+    this.displayGymForm = "block";
+  }
+
+  closeGymForm() {
+    this.displayGymForm = "none";
+    this.editingGym = null;
+    this.gymForm.reset();
+  }
+
+  private async saveEdit() {
+    try {
+      let updated: Gym = {
+        id: this.editingGym!.id,
+        name: this.gymForm.value.name!,
+        address: this.gymForm.value.address ?? '',
+        place_id: this.gymForm.value.place_id ?? '',
+        live_feed: this.gymForm.value.live_feed ?? ''
+      };
+      await this.gymBuilder.updateGym(this.ddb, updated);
+      this.closeGymForm();
+      await this.loadGyms();
+      this.popUpMsg = "Gimnasio Actualizado!";
+      this.openPopup();
+    } catch (err) {
+      console.error("Error updating gym", err)
+      this.popUpMsg = "Error! Gimnasio no actualizado. Intenta otra vez.";
+      this.openPopup();
+    }
+  }
 
   openPopup() {
     this.displayStyle = "block";

--- a/angular-app/src/app/restricted-area/restricted-area.component.ts
+++ b/angular-app/src/app/restricted-area/restricted-area.component.ts
@@ -142,11 +142,11 @@ export class RestrictedAreaComponent {
         // tabs inside Evaluar Partido, so only admins keep a dropdown — and it
         // includes "Evaluar Partido" so they can navigate back to it.
         this.menuItems = this.menuItems.concat([
-          {value: "addGym", text: "Add Gym"},
+          {value: "addGym", text: "Gimnasios"},
           {value: "editMatch", text: "Partidos"},
           {value: "scouting", text: "Scouting"},
-          {value: "listPlayers", text: "Jugadores Registrados"},
-          {value: "viewUsers", text: "Usuarios Registrados"},
+          {value: "listPlayers", text: "Jugadores"},
+          {value: "viewUsers", text: "Usuarios"},
           {value: "listReports", text: "Reportes"}
         ]);
       }
@@ -154,7 +154,7 @@ export class RestrictedAreaComponent {
         // "Registrar Equipo" is reached via the "+" button in Equipos
         // Registrados, so it's no longer a standalone menu entry.
         this.menuItems = this.menuItems.concat([
-          {value: "listTeams", text: "Equipos Registrados"},
+          {value: "listTeams", text: "Equipos"},
         ]);
       }
 

--- a/angular-app/src/app/results/brackets/brackets.component.html
+++ b/angular-app/src/app/results/brackets/brackets.component.html
@@ -42,6 +42,13 @@
                                     {{ match.location.name }}
                                 </a>
                                 <span class="tournament-bracket__time">{{ match.time }}</span>
+                                <!-- Gym's live transmission, only when one is registered. -->
+                                <a class="tournament-bracket__feed" *ngIf="match.location.live_feed"
+                                   [href]="match.location.live_feed" target="_blank" rel="noopener"
+                                   (click)="$event.stopPropagation()"
+                                   title="Transmisión en Vivo" aria-label="Transmisión en Vivo">
+                                    <i class="fas fa-video"></i>
+                                </a>
                             </div>
                         </div>
                     </ng-template>

--- a/angular-app/src/app/results/brackets/brackets.component.scss
+++ b/angular-app/src/app/results/brackets/brackets.component.scss
@@ -366,6 +366,25 @@
   color: $text-color1;
 }
 
+// Live transmission — a round icon button so it stands out from the details text.
+.tournament-bracket__feed {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.9em;
+  height: 1.9em;
+  margin-top: 0.25em;
+  background-color: $header-color1;
+  color: $bg-color1;
+  border-radius: 50%;
+  text-decoration: none;
+
+  &:hover {
+    color: $bg-color1;
+    opacity: 0.85;
+  }
+}
+
 
 
 /* unvisited link */

--- a/angular-app/src/app/results/groups/groups.component.html
+++ b/angular-app/src/app/results/groups/groups.component.html
@@ -17,6 +17,12 @@
                     <div class="match-card match-card--readonly mb-3">
                         <!-- Category tag pinned top-left. -->
                         <span class="match-badge">{{match.category}}</span>
+                        <!-- Gym's live transmission pinned top-right, only when one is registered. -->
+                        <a class="match-live-feed" *ngIf="match.location.live_feed"
+                           [href]="match.location.live_feed" target="_blank" rel="noopener"
+                           title="Transmisión en Vivo" aria-label="Transmisión en Vivo">
+                            <i class="fas fa-video"></i>
+                        </a>
 
                         <div class="match-card__meta">
                             <!-- Primary line: which group + when. -->

--- a/angular-app/src/app/results/standing-matches/standing-matches.component.html
+++ b/angular-app/src/app/results/standing-matches/standing-matches.component.html
@@ -17,6 +17,12 @@
                     <div class="match-card match-card--readonly mb-3">
                         <!-- Category tag pinned top-left. -->
                         <span class="match-badge">{{match.category}}</span>
+                        <!-- Gym's live transmission pinned top-right, only when one is registered. -->
+                        <a class="match-live-feed" *ngIf="match.location.live_feed"
+                           [href]="match.location.live_feed" target="_blank" rel="noopener"
+                           title="Transmisión en Vivo" aria-label="Transmisión en Vivo">
+                            <i class="fas fa-video"></i>
+                        </a>
 
                         <div class="match-card__meta">
                             <!-- Primary line: which game + when. -->

--- a/angular-app/src/styles.scss
+++ b/angular-app/src/styles.scss
@@ -294,6 +294,31 @@ td{
         opacity: 0.8;
     }
 
+    // Live transmission for the gym — a round icon button pinned to the card's
+    // top-right corner, mirroring the action button slot on editable cards.
+    .match-live-feed{
+        position: absolute;
+        top: 0.75rem;
+        right: 0.75rem;
+        z-index: 1;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 2.15rem;
+        height: 2.15rem;
+        border-radius: 50%;
+        background-color: $header-color1;
+        color: $bg-color1;
+        font-size: 0.9rem;
+        text-decoration: none;
+        cursor: pointer;
+    }
+
+    .match-live-feed:hover{
+        color: $bg-color1;
+        opacity: 0.85;
+    }
+
     .match-card__scoreboard{
         display: grid;
         grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);


### PR DESCRIPTION
## Summary

Adds a `live_feed` attribute to the gym resource so each gym can carry its
Facebook live transmission URL, and surfaces it wherever matches are shown.

**Public views** — a round video icon button linking to the transmission:
- Standings and Fase de Grupos match cards: pinned to the card's top-right
  corner, mirroring the action-button slot used on editable cards.
- Bracket: inside the expanded match details, as an icon-only button.

Only rendered when the gym has a feed registered, so a missing icon means
"no transmission".

**Admin (Gimnasios)** — restructured to match the Jugadores flow:
- Form moved out of the main page into a modal behind a `+` button.
- Clicking a table row opens that gym in the modal with its values loaded,
  so the whole record is editable — not just the feed.
- The `id` is read-only while editing: it's part of the partition key
  (`gym.<id>`) and matches reference gyms by it, so changing it would
  orphan match locations.
- A Transmisión column shows the video icon for gyms that have a link, and
  clicking it opens the transmission (`stopPropagation` keeps it from also
  opening the row editor).

Also shortens the admin dropdown labels: Jugadores, Equipos, Usuarios, Gimnasios.

## Notes

- Gyms registered before live feeds existed have no `live_feed` attribute,
  so `buildGym` reads it with `?.`.
- `updateGym` leaves `cy` untouched, so editing an older gym doesn't pull it
  into the current tournament year.
- The Google Maps link was removed from the address cell in the gym table,
  since the row is now clickable.
- The four gym transmission URLs still need to be entered through the admin UI.

## Test plan

- `ng build --configuration development` passes.
- Manual: verify the icon appears only on cards whose gym has a feed, that it
  opens the right transmission, and that creating vs. editing a gym both work
  from the modal.