### PR TITLE
Only cache immutable S3 images, always refetch mutable objects

### DIFF
--- a/angular-app/src/app/aws-clients/cache.ts
+++ b/angular-app/src/app/aws-clients/cache.ts
@@ -9,7 +9,7 @@ interface CacheEntry {
 export class Cache {
     private cache: Map<string, CacheEntry> = new Map();
     private readonly TTL_MS = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
-    private readonly MAX_SIZE_BYTES = 100 * 1024 * 1024; // 150 MB in bytes
+    private readonly MAX_SIZE_BYTES = 150 * 1024 * 1024; // 150 MB in bytes
     private currentSize: number = 0;
     private cleanupInterval: NodeJS.Timeout | null = null;
 
@@ -182,7 +182,7 @@ export class Cache {
             currentSizeBytes: this.currentSize,
             currentSizeMB: Math.round((this.currentSize / (1024 * 1024)) * 100) / 100,
             maxSizeBytes: this.MAX_SIZE_BYTES,
-            maxSizeMB: 150,
+            maxSizeMB: Math.round((this.MAX_SIZE_BYTES / (1024 * 1024)) * 100) / 100,
             utilizationPercent: Math.round((this.currentSize / this.MAX_SIZE_BYTES) * 10000) / 100,
             oldestEntry: entries.length > 0 ? new Date(oldestTimestamp) : undefined,
             newestEntry: entries.length > 0 ? new Date(newestTimestamp) : undefined,

--- a/angular-app/src/app/aws-clients/s3.ts
+++ b/angular-app/src/app/aws-clients/s3.ts
@@ -1,7 +1,7 @@
 import { S3Client, GetObjectCommand, ListObjectsCommand, ListObjectsCommandInput, GetObjectCommandInput, PutObjectCommand, PutObjectCommandInput, DeleteObjectCommand, DeleteObjectCommandInput } from "@aws-sdk/client-s3";
 import { REGION, COGNITO_UNAUTHENTICATED_CREDENTIALS, TOURNAMENT_YEAR } from "./constants";
 import { AwsCredentialIdentity, Provider } from "@aws-sdk/types"
-import { Cache } from "./cache";
+import { Cache, globalCache } from "./cache";
 
 const client = new S3Client({ 
     region: REGION,
@@ -38,15 +38,27 @@ export enum ReportType {
     STANDINGS = 'standings'
 }
 
+// Sent as `response-cache-control` on reads of objects that get rewritten in
+// place under a stable key, so the browser never serves a stale copy. It also
+// changes the request URL, which evicts anything already cached under the plain
+// object URL.
+const NO_CACHE = 'no-cache, no-store, must-revalidate'
+
 export { client };
 export class S3 {
-    
+
     client: S3Client;
-    cache: Cache;
+    // Images keyed per entity only (player photos, team logos). Mutable objects
+    // — JSON reports, payment receipts, waivers — bypass this; see readObject and
+    // downloadFile's useCache flag.
+    //
+    // Shared process-wide rather than per instance: every component builds its
+    // own S3, so a per-instance cache never gets a hit across views and each one
+    // would leak its own cleanup interval.
+    cache: Cache = globalCache;
 
     constructor(client: S3Client){
         this.client = client
-        this.cache = new Cache();
     }
     async listObjects(): Promise<any> {
         console.log("Listing all match files")
@@ -66,11 +78,17 @@ export class S3 {
         }
     }
 
+    /**
+     * Read a JSON report (tops, player reports, standings). Never cached: these
+     * files are rewritten in place as matches are scored, so a cached copy would
+     * show stale stats and standings.
+     */
     async readObject(name: string, type: ReportType): Promise<string | undefined> {
         console.log(`Reading s3 object for ${name}`)
         let input: GetObjectCommandInput = {
             Bucket: GLADIADORES_BUCKET_NAME,
-            Key: `${REPORT_PATH}/${type}/${name}.json`
+            Key: `${REPORT_PATH}/${type}/${name}.json`,
+            ResponseCacheControl: NO_CACHE
         }
         console.log('input', input)
         try{
@@ -174,17 +192,28 @@ export class S3 {
     }
 
     /**
-     * Destroy the S3 instance and cleanup cache resources
+     * Drop everything this instance has cached. The cache is shared across all
+     * S3 instances, so this affects every view — it tears down the cleanup
+     * interval too, and is not meant for per-component teardown.
      */
     destroy(): void {
         this.cache.destroy();
         console.log('S3 instance destroyed and cache cleaned up');
     }
 
+    /**
+     * Download an image under the images/ path. Cached for 24h by default, which
+     * suits objects keyed per entity (player photos, team logos) that only change
+     * when someone uploads a replacement — and uploadFile invalidates those.
+     *
+     * Pass useCache=false for keys that are rewritten in place, such as the
+     * index-shuffled payment receipts: that skips the in-memory cache and also
+     * tells the browser not to reuse its own cached response.
+     */
     async downloadFile(fileName: string, useCache: boolean = true): Promise<Uint8Array | undefined> {
         const objectKey = `${IMAGE_PATH}/${fileName}`;
         console.log(`Downloading file: ${objectKey}`)
-        
+
         // Check cache first if caching is enabled
         if (useCache) {
             const cachedData = this.cache.get(objectKey);
@@ -194,10 +223,11 @@ export class S3 {
             }
             console.log(`Cache miss for file: ${objectKey}, downloading from S3`);
         }
-        
+
         const input: GetObjectCommandInput = {
             Bucket: GLADIADORES_BUCKET_NAME,
-            Key: objectKey
+            Key: objectKey,
+            ...(useCache ? {} : {ResponseCacheControl: NO_CACHE})
         };
 
         console.log('Download input:', input);
@@ -225,13 +255,19 @@ export class S3 {
         }
     }
 
+    /**
+     * Download a file along with its content type, used for the signed liability
+     * waivers. Not cached: a re-uploaded waiver keeps the same key, so a cached
+     * copy would keep showing the superseded document.
+     */
     async downloadFileWithType(fileName: string, path: string = IMAGE_PATH): Promise<{data: Uint8Array, contentType: string} | undefined> {
         const objectKey = `${path}/${fileName}`;
         console.log(`Downloading file with type: ${objectKey}`)
 
         const input: GetObjectCommandInput = {
             Bucket: GLADIADORES_BUCKET_NAME,
-            Key: objectKey
+            Key: objectKey,
+            ResponseCacheControl: NO_CACHE
         };
 
         try {
@@ -253,11 +289,16 @@ export class S3 {
      * Download the blank liability-waiver template (bucket root, keyed by year).
      * Returns the file bytes + content type, or undefined when the template
      * for the current tournament year has not been uploaded yet.
+     *
+     * Not cached: the key is only keyed by year, so a corrected template
+     * replaces it in place and a stale copy would be handed to coaches. This
+     * also doubles as the availability check the modal relies on.
      */
     async downloadLiabilityWaiverTemplate(): Promise<{data: Uint8Array, contentType: string} | undefined> {
         const input: GetObjectCommandInput = {
             Bucket: GLADIADORES_BUCKET_NAME,
-            Key: LIABILITY_WAIVER_TEMPLATE_KEY
+            Key: LIABILITY_WAIVER_TEMPLATE_KEY,
+            ResponseCacheControl: NO_CACHE
         };
 
         try {

--- a/angular-app/src/app/restricted-area/list-teams/list-teams.component.ts
+++ b/angular-app/src/app/restricted-area/list-teams/list-teams.component.ts
@@ -230,7 +230,10 @@ export class ListTeamsComponent {
 
       for (let i = 0; i < 10; i++) {
         const fileName = TeamBuilder.getReceiptFileName(team.name, team.id, i);
-        const data = await this.s3.downloadFile(fileName);
+        // Uncached: receipt keys are positional, so deleting one shifts every
+        // later file down into a key that already exists. An admin reviewing a
+        // payment has to see what the coach uploaded last, not a shifted copy.
+        const data = await this.s3.downloadFile(fileName, false);
         if (data) {
           const blob = new Blob([data as any]);
           this.reviewReceiptUrls.push(URL.createObjectURL(blob));


### PR DESCRIPTION
The JSON reports the Retiarius workflows publish (stats, player reports, standings) are rewritten in place under a stable key, so the browser was free to serve a stale response and show outdated stats and standings. Send response-cache-control on those reads instead.

The same applies to any object replaced under a key that already existed, so signed liability waivers and the year-keyed waiver template are read fresh too. Images keyed per entity (player photos, team logos) keep their 24h cache, since uploadFile invalidates them on replacement.

Also fixes two related issues found while auditing the read paths:

- Payment receipts use positional keys and deleting one shifts every later file down a slot, so list-teams' cached read could show a pre-shift image. It now matches view-teams and skips the cache.
- Every component builds its own S3, and the constructor built a private Cache per instance, so image caches never got a hit across views and each instance leaked a cleanup interval that nothing cleared. Use the globalCache singleton that cache.ts already exported.

Correct MAX_SIZE_BYTES to the documented 150 MB and derive maxSizeMB from it so the reported limit cannot drift from the real one again.