### PR TITLE
Add group, team, gym and date filters to Partidos

### DIFF
--- a/angular-app/src/app/aws-clients/constants.ts
+++ b/angular-app/src/app/aws-clients/constants.ts
@@ -4,6 +4,12 @@ import { CognitoIdentity } from "../interfaces/cognito-identity";
 export var TOURNAMENT_YEAR = new Date().getFullYear().toString()
 export const TOURNAMENT_DAYS = [31, 1, 2]
 
+// Group-phase names in display order, and the name given to the standings
+// matches. Both are stored in a match's `juego`, so they are what tells the
+// group phase, the standings and the partidos filters which matches to show.
+export const GROUP_NAMES = ["Grupo 1", "Grupo 2", "Grupo 3", "Grupo 4", "Grupo A", "Grupo B", "Grupo C"]
+export const STANDING_GAME_NAME = 'Standing'
+
 export const REGION = 'us-east-1'
 export const COGNITO_IDENTITY_POOL = 'us-east-1:66bd9702-735d-4e68-a155-76fb7fb20547'
 export const COGNITO_UNAUTHENTICATED_IDENTITY_POOL = 'us-east-1:adf17da9-3e55-4f06-b8fa-53554f6f4dbf'

--- a/angular-app/src/app/interfaces/match-filters.ts
+++ b/angular-app/src/app/interfaces/match-filters.ts
@@ -1,0 +1,18 @@
+// Filters chosen on the partidos page and applied by the results sections
+// (Standings and Fase de Grupos). `null` means "no filter on this field".
+//
+// The object is replaced rather than mutated whenever a filter changes, so the
+// sections receiving it as an @Input() see it in ngOnChanges.
+export interface MatchFilters {
+    group: string | null
+    teamId: string | null
+    gymId: string | null
+    day: string | null
+}
+
+export const EMPTY_MATCH_FILTERS: MatchFilters = {
+    group: null,
+    teamId: null,
+    gymId: null,
+    day: null
+}

--- a/angular-app/src/app/partidos/partidos.component.html
+++ b/angular-app/src/app/partidos/partidos.component.html
@@ -32,7 +32,75 @@
 
     <app-awards *ngIf="showAwards"></app-awards>
     <app-brackets *ngIf="showBrackets" [category]="selectedCategory" [teamLogos]="teamLogos"></app-brackets>
-    <app-standing-matches *ngIf="showStandings" [category]="selectedCategory" [teamLogos]="teamLogos"></app-standing-matches>
-    <app-groups *ngIf="showGroups" [category]="selectedCategory" [teamLogos]="teamLogos"></app-groups>
+
+    <!-- Extra filters, applied to Standings and Fase de Grupos only. Placed
+         right above those sections (the brackets above are unfiltered). Grupo
+         doesn't apply to Standings (those matches belong to no group), so that
+         section responds to the other three. -->
+    <div class="col col-12 partidos-filters" *ngIf="showStandings||showGroups">
+        <div class="filter-bar">
+            <div class="d-flex justify-content-between align-items-center gap-2">
+                <button class="btn btn-warning btn-sm" type="button"
+                        (click)="toggleFilters()"
+                        [attr.aria-expanded]="!filtersCollapsed"
+                        aria-controls="partidosFilters">
+                    <i class="fas" [class.fa-chevron-down]="filtersCollapsed" [class.fa-chevron-up]="!filtersCollapsed"></i>
+                    <span class="ms-2">Filtros</span>
+                </button>
+
+                <span class="filter-active-badge" *ngIf="hasActiveFilters">
+                    <i class="fas fa-filter"></i>&nbsp;Filtros activos
+                </span>
+            </div>
+
+            <div id="partidosFilters" class="collapse" [class.show]="!filtersCollapsed">
+                <form [formGroup]="filterForm" class="mt-3">
+                    <div class="row g-2">
+                        <div class="col-6 col-md-3" *ngIf="groupOptions.length > 0">
+                            <select class="form-select" id="groupFilter" formControlName="group" (change)="applyFilters()"
+                                    aria-label="Filtrar por grupo">
+                                <option [ngValue]="null">Grupo</option>
+                                <option *ngFor="let group of groupOptions" [ngValue]="group">{{group}}</option>
+                            </select>
+                        </div>
+                        <div class="col-6 col-md-3" *ngIf="teamOptions.length > 0">
+                            <select class="form-select" id="teamFilter" formControlName="teamId" (change)="applyFilters()"
+                                    aria-label="Filtrar por equipo">
+                                <option [ngValue]="null">Equipo</option>
+                                <option *ngFor="let team of teamOptions" [ngValue]="team.id">{{team.name}}</option>
+                            </select>
+                        </div>
+                        <div class="col-6 col-md-3" *ngIf="gymOptions.length > 0">
+                            <select class="form-select" id="gymFilter" formControlName="gymId" (change)="applyFilters()"
+                                    aria-label="Filtrar por gimnasio">
+                                <option [ngValue]="null">Gimnasio</option>
+                                <option *ngFor="let gym of gymOptions" [ngValue]="gym.id">{{gym.name}}</option>
+                            </select>
+                        </div>
+                        <div class="col-6 col-md-3" *ngIf="dayOptions.length > 0">
+                            <select class="form-select" id="dayFilter" formControlName="day" (change)="applyFilters()"
+                                    aria-label="Filtrar por fecha">
+                                <option [ngValue]="null">Fecha</option>
+                                <option *ngFor="let day of dayOptions" [ngValue]="day.key">{{day.label | titlecase}}</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="row mt-2">
+                        <div class="col-12 text-center">
+                            <button class="btn btn-outline-light btn-sm" type="button" (click)="clearFilters()"
+                                    title="Limpiar filtros" aria-label="Limpiar filtros">
+                                <i class="fas fa-rotate-left"></i>
+                            </button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <app-standing-matches *ngIf="showStandings" [category]="selectedCategory" [teamLogos]="teamLogos"
+                          [filters]="selectedFilters"></app-standing-matches>
+    <app-groups *ngIf="showGroups" [category]="selectedCategory" [teamLogos]="teamLogos"
+                [filters]="selectedFilters"></app-groups>
 </div>
 </div>

--- a/angular-app/src/app/partidos/partidos.component.scss
+++ b/angular-app/src/app/partidos/partidos.component.scss
@@ -27,6 +27,24 @@
     margin-bottom: 1.25rem;
 }
 
+// Group/team/gym/date filters for the Standings and Fase de Grupos sections.
+// Sits between the category toggle and the sections it drives.
+.partidos-filters {
+    margin-bottom: 1.25rem;
+}
+
+// "Filtros activos" hint, so a collapsed filter bar still shows that the lists
+// below are narrowed down.
+.filter-active-badge {
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    background-color: $active-tint-color;
+    color: $header-color1;
+    font-size: 0.85rem;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
 // Segmented category toggle matching the reports page view-switcher.
 .view-toggle {
     display: inline-flex;

--- a/angular-app/src/app/partidos/partidos.component.ts
+++ b/angular-app/src/app/partidos/partidos.component.ts
@@ -1,16 +1,29 @@
 import { Component, QueryList, ViewChildren } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
 import { BracketsComponent } from '../results/brackets/brackets.component';
 import { StandingMatchesComponent } from '../results/standing-matches/standing-matches.component';
 import { GroupsComponent } from '../results/groups/groups.component';
 import { AwardsComponent } from '../results/awards/awards.component';
-import { COGNITO_UNAUTHENTICATED_CREDENTIALS, TOURNAMENT_YEAR, REGION } from '../aws-clients/constants';
+import {
+  COGNITO_UNAUTHENTICATED_CREDENTIALS,
+  TOURNAMENT_YEAR,
+  REGION,
+  GROUP_NAMES,
+  STANDING_GAME_NAME
+} from '../aws-clients/constants';
 import { FeatureFlag } from '../interfaces/feature-flag';
 import { FeatureFlagBuilder } from '../Builders/feature-flag-builder';
 import { TeamBuilder } from '../Builders/team-builder';
+import { MatchBuilder } from '../Builders/match-builder';
 import { DynamoDb } from '../aws-clients/dynamodb';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { S3 } from '../aws-clients/s3';
 import { S3Client } from '@aws-sdk/client-s3';
+import { Match } from '../interfaces/match';
+import { MatchTeam } from '../interfaces/team';
+import { Gym } from '../interfaces/gym';
+import { MatchFilters, EMPTY_MATCH_FILTERS } from '../interfaces/match-filters';
+import { matchDateKey, toLocalDateTimeString } from '../utils/utils';
 
 @Component({
   selector: 'app-partidos',
@@ -20,8 +33,10 @@ import { S3Client } from '@aws-sdk/client-s3';
 export class PartidosComponent {
 
   constructor(
+    private fb: FormBuilder,
     private featureFlagBuilder: FeatureFlagBuilder,
-    private teamBuilder: TeamBuilder
+    private teamBuilder: TeamBuilder,
+    private matchBuilder: MatchBuilder
   ){
   }
 
@@ -47,6 +62,32 @@ export class PartidosComponent {
   categories = ["elite", "aprendiz"] as const;
   selectedCategory: 'elite' | 'aprendiz' = 'elite';
 
+  // Extra filters for the Standings and Fase de Grupos sections. The brackets
+  // and awards are unfiltered: a bracket only reads as a bracket whole.
+  // Open on arrival: the date filter starts on today, so the bar has to be
+  // visible for people to see why they aren't looking at every match.
+  filtersCollapsed = false;
+  selectedFilters: MatchFilters = EMPTY_MATCH_FILTERS;
+
+  filterForm = this.fb.group({
+    group: [null as string | null],
+    teamId: [null as string | null],
+    gymId: [null as string | null],
+    day: [null as string | null]
+  });
+
+  // Dropdown options, derived from the matches the filtered sections actually
+  // show so the lists never offer a choice that yields nothing. Rebuilt when the
+  // category changes, since teams and groups don't span categories.
+  groupOptions: string[] = [];
+  teamOptions: MatchTeam[] = [];
+  gymOptions: Gym[] = [];
+  dayOptions: {key: string, label: string}[] = [];
+
+  // Matches of the filtered sections (group phase + standings), all categories,
+  // kept to build the dropdown options from.
+  private filterableMatches: Match[] = [];
+
   @ViewChildren(BracketsComponent) bracketChild!: QueryList<BracketsComponent>;
   @ViewChildren(StandingMatchesComponent) standingsChild!: QueryList<StandingMatchesComponent>;
   @ViewChildren(GroupsComponent) groupsChild!: QueryList<GroupsComponent>;
@@ -63,7 +104,9 @@ export class PartidosComponent {
     this.loading = false;
     this.teamLogos = {};
     void this.loadSharedTeamLogos();
+    // After showViews(), which sets the flags loadFilterOptions() checks.
     await this.showViews();
+    void this.loadFilterOptions();
   }
 
   private async loadSharedTeamLogos() {
@@ -71,8 +114,114 @@ export class PartidosComponent {
     this.teamLogos = loadedLogos;
   }
 
+  // The filtered sections each fetch their own matches; this is a separate read
+  // used only to know which options to offer. It runs alongside them so the
+  // results aren't held back by the filter bar.
+  private async loadFilterOptions() {
+    if (!this.showStandings && !this.showGroups) {
+      return;
+    }
+
+    const allMatches = await this.matchBuilder.getListOfMatch(this.ddb, TOURNAMENT_YEAR);
+    this.filterableMatches = allMatches.filter(
+      match => GROUP_NAMES.includes(match.juego) || match.juego === STANDING_GAME_NAME
+    );
+    this.buildFilterOptions();
+    // The day options only exist now, so this is the first point the date
+    // default can be resolved.
+    this.applyDefaultFilters();
+  }
+
+  // Options for the currently selected category only: a team or group from the
+  // other category would filter every visible match away.
+  private buildFilterOptions() {
+    const matches = this.filterableMatches.filter(match => match.category === this.selectedCategory);
+
+    this.groupOptions = GROUP_NAMES.filter(group => matches.some(match => match.juego === group));
+
+    const teams = new Map<string, MatchTeam>();
+    const gyms = new Map<string, Gym>();
+    const days = new Map<string, string>();
+
+    for (const match of matches) {
+      for (const team of [match.homeTeam, match.visitorTeam]) {
+        if (team?.id && !teams.has(team.id)) teams.set(team.id, team);
+      }
+      if (match.location?.id && !gyms.has(match.location.id)) gyms.set(match.location.id, match.location);
+
+      const dayKey = matchDateKey(match);
+      if (dayKey && !days.has(dayKey)) days.set(dayKey, this.formatDayLabel(match.datetime!));
+    }
+
+    this.teamOptions = [...teams.values()].sort((a, b) => a.name.localeCompare(b.name, 'es'));
+    this.gymOptions = [...gyms.values()].sort((a, b) => a.name.localeCompare(b.name, 'es'));
+    // Keys are `YYYY-MM-DD`, so a plain string sort is chronological.
+    this.dayOptions = [...days.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, label]) => ({key, label}));
+  }
+
+  // During the tournament the day being played is what people come to see, so
+  // the date filter starts on it. Off-tournament there is no match today, and
+  // defaulting to a day with nothing on it would look like an empty page — so
+  // the filter stays open and every day is shown.
+  private defaultDayKey(): string | null {
+    const todayKey = toLocalDateTimeString(new Date()).split('T')[0];
+    return this.dayOptions.some(day => day.key === todayKey) ? todayKey : null;
+  }
+
+  private applyDefaultFilters() {
+    this.filterForm.reset({
+      group: null,
+      teamId: null,
+      gymId: null,
+      day: this.defaultDayKey()
+    });
+    this.applyFilters();
+  }
+
+  private formatDayLabel(datetime: Date): string {
+    return new Intl.DateTimeFormat('es-MX', {
+      weekday: 'long',
+      day: '2-digit',
+      month: 'long'
+    }).format(datetime);
+  }
+
+  toggleFilters() {
+    this.filtersCollapsed = !this.filtersCollapsed;
+  }
+
+  // A new object each time: the filtered sections receive it as an @Input() and
+  // detect the change by identity.
+  applyFilters() {
+    this.selectedFilters = {
+      group: this.filterForm.value.group || null,
+      teamId: this.filterForm.value.teamId || null,
+      gymId: this.filterForm.value.gymId || null,
+      day: this.filterForm.value.day || null
+    };
+  }
+
+  clearFilters() {
+    this.filterForm.reset();
+    this.applyFilters();
+  }
+
+  get hasActiveFilters(): boolean {
+    const {group, teamId, gymId, day} = this.selectedFilters;
+    return !!(group || teamId || gymId || day);
+  }
+
   selectCategory(category: 'elite' | 'aprendiz'){
+    if (this.selectedCategory === category) {
+      return;
+    }
     this.selectedCategory = category;
+    // Groups and teams are per-category, so a selection made in the other one
+    // would hide everything. Back to just the date default.
+    this.buildFilterOptions();
+    this.applyDefaultFilters();
   }
 
   async showViews(){

--- a/angular-app/src/app/results/groups/groups.component.html
+++ b/angular-app/src/app/results/groups/groups.component.html
@@ -53,27 +53,23 @@
                 </ng-template>
 
                 <div class="row" *ngIf="!loading">
-                    <div class="col col-12" *ngIf="category === 'aprendiz'">
+                    <!-- One column per group that still has matches after the
+                         page's filters; both categories share this list. -->
+                    <div class="col col-12">
                         <div class="row">
-                            <div class="col col-12 col-md-6" *ngFor="let group of groups">
-                                <h3 class="text-center"  *ngIf="groupMatches[group].length > 0">{{group}}</h3>
-                                <ng-container *ngFor="let match of groupMatches[group]"
+                            <div class="col col-12 col-md-6" *ngFor="let entry of visibleGroups">
+                                <h3 class="text-center">{{entry.group}}</h3>
+                                <ng-container *ngFor="let match of entry.matches"
                                     [ngTemplateOutlet]="matchCard"
                                     [ngTemplateOutletContext]="{ $implicit: match }">
                                 </ng-container>
                             </div>
                         </div>
                     </div>
-                    <div class="col col-12" *ngIf="category === 'elite'">
-                        <div class="row">
-                            <div class="col col-12 col-md-6" *ngFor="let group of groups" >
-                                <h3 class="text-center" *ngIf="groupMatchesElite[group].length > 0">{{group}}</h3>
-                                <ng-container *ngFor="let match of groupMatchesElite[group]"
-                                    [ngTemplateOutlet]="matchCard"
-                                    [ngTemplateOutletContext]="{ $implicit: match }">
-                                </ng-container>
-                            </div>
-                        </div>
+
+                    <!-- The category has group matches, but the filters matched none. -->
+                    <div class="col col-12 text-center" *ngIf="visibleGroups.length === 0 && hasCategoryMatches">
+                        <p class="empty-filter-message">No hay partidos que coincidan con los filtros seleccionados.</p>
                     </div>
 
                     <div class="row foto-slider" *ngIf="selectedYear==='2023'" >

--- a/angular-app/src/app/results/groups/groups.component.scss
+++ b/angular-app/src/app/results/groups/groups.component.scss
@@ -43,6 +43,15 @@ a:link {
   }
 
 
+// Shown in place of the groups when the page's filters match no group match.
+// The accordion body is light, so this reads against it rather than the page.
+.empty-filter-message {
+    margin: 0;
+    padding: 1rem 0;
+    color: $bg-color1;
+    font-weight: 600;
+}
+
 .tournament-match__logo {
     width: 1.8em;
     height: 1.8em;

--- a/angular-app/src/app/results/groups/groups.component.ts
+++ b/angular-app/src/app/results/groups/groups.component.ts
@@ -1,12 +1,14 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { HttpClient } from '@angular/common/http'
 import { Match } from '../../interfaces/match';
 import { FormBuilder } from '@angular/forms';
 import { MatchBuilder } from '../../Builders/match-builder';
 import { DynamoDb } from '../../aws-clients/dynamodb';
-import { COGNITO_UNAUTHENTICATED_CREDENTIALS, TOURNAMENT_YEAR, REGION } from '../../aws-clients/constants'
+import { COGNITO_UNAUTHENTICATED_CREDENTIALS, TOURNAMENT_YEAR, REGION, GROUP_NAMES } from '../../aws-clients/constants'
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { MatchTeam } from 'src/app/interfaces/team';
+import { MatchFilters, EMPTY_MATCH_FILTERS } from 'src/app/interfaces/match-filters';
+import { applyMatchFilters } from 'src/app/utils/utils';
 
 
 
@@ -17,7 +19,7 @@ const LOGO_PLACEHOLDER = 'assets/logo_gray.png';
   templateUrl: './groups.component.html',
   styleUrls: ['./groups.component.scss']
 })
-export class GroupsComponent implements OnInit {
+export class GroupsComponent implements OnInit, OnChanges {
   ddbClient = new DynamoDBClient({ 
     region: REGION,
     credentials: COGNITO_UNAUTHENTICATED_CREDENTIALS
@@ -28,14 +30,21 @@ export class GroupsComponent implements OnInit {
   loading = true;
 
   isEditing: boolean = false;
-  groups = ["Grupo 1", "Grupo 2", "Grupo 3", "Grupo 4", "Grupo A", "Grupo B", "Grupo C"]
+  groups = GROUP_NAMES
 
   groupMatches: {[group: string]: Match[]} = {}
   groupMatchesElite: {[group: string]: Match[]} = {}
 
+  // What the template renders: the selected category's groups with the parent's
+  // filters applied, and only the groups that still have matches. Kept in sync
+  // by applyFilters().
+  visibleGroups: {group: string, matches: Match[]}[] = []
+
   // Category to show, controlled by the shared toggle in the parent results page.
   @Input() category: 'elite' | 'aprendiz' = 'elite';
   @Input() teamLogos: {[teamId: string]: string} = {};
+  // Group/team/gym/date filters from the parent page.
+  @Input() filters: MatchFilters = EMPTY_MATCH_FILTERS;
 
   constructor(private fb: FormBuilder, 
     private matchBuilder: MatchBuilder,
@@ -46,7 +55,13 @@ export class GroupsComponent implements OnInit {
 
   async ngOnInit() {
     await this.loadMatches(TOURNAMENT_YEAR)
-  }  
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['category'] || changes['filters']) {
+      this.applyFilters();
+    }
+  }
 
   async loadMatches(year: string){
 
@@ -74,6 +89,27 @@ export class GroupsComponent implements OnInit {
       }
     });
     this.loading = false;
+    this.applyFilters();
+  }
+
+  // Recomputed on change rather than exposed as a getter: a getter would hand
+  // *ngFor new objects every change-detection pass and re-render every card.
+  private applyFilters() {
+    const categoryMatches = this.category === 'elite' ? this.groupMatchesElite : this.groupMatches;
+
+    this.visibleGroups = this.groups
+      .map(group => ({
+        group,
+        matches: applyMatchFilters(categoryMatches[group] ?? [], this.filters)
+      }))
+      .filter(entry => entry.matches.length > 0);
+  }
+
+  // Whether the category has any group match before filtering, to tell "nothing
+  // published yet" apart from "the filters matched nothing".
+  get hasCategoryMatches(): boolean {
+    const categoryMatches = this.category === 'elite' ? this.groupMatchesElite : this.groupMatches;
+    return Object.values(categoryMatches).some(matches => matches.length > 0);
   }
 
   teamLogoUrl(team: MatchTeam | undefined): string {

--- a/angular-app/src/app/results/standing-matches/standing-matches.component.html
+++ b/angular-app/src/app/results/standing-matches/standing-matches.component.html
@@ -1,4 +1,4 @@
-<div class="row justify-content-md-center" *ngIf="hasVisibleMatches || loading">
+<div class="row justify-content-md-center" *ngIf="hasCategoryMatches || loading">
     <div class="accordion accordion-flush modern-accordion" id="accordionFlushExample">
         <div class="accordion-item">
             <h2 class="accordion-header">
@@ -53,17 +53,15 @@
                 </ng-template>
 
                 <div class="row" *ngIf="!loading">
-                    <div class="col col-12 padded-col" *ngIf="category === 'aprendiz' && standingMatches.length>0">
-                        <ng-container *ngFor="let match of standingMatches"
+                    <div class="col col-12 padded-col" *ngIf="hasVisibleMatches">
+                        <ng-container *ngFor="let match of visibleMatches"
                             [ngTemplateOutlet]="matchCard"
                             [ngTemplateOutletContext]="{ $implicit: match }">
                         </ng-container>
                     </div>
-                    <div class="col col-12 padded-col" *ngIf="category === 'elite' && standingMatchesElite.length>0">
-                        <ng-container *ngFor="let match of standingMatchesElite"
-                            [ngTemplateOutlet]="matchCard"
-                            [ngTemplateOutletContext]="{ $implicit: match }">
-                        </ng-container>
+                    <!-- The category has standings, but the filters matched none of them. -->
+                    <div class="col col-12 padded-col text-center" *ngIf="!hasVisibleMatches">
+                        <p class="empty-filter-message">No hay partidos que coincidan con los filtros seleccionados.</p>
                     </div>
                 </div>
             </div>

--- a/angular-app/src/app/results/standing-matches/standing-matches.component.scss
+++ b/angular-app/src/app/results/standing-matches/standing-matches.component.scss
@@ -45,6 +45,15 @@ a:link {
     color: white;
   }
 
+// Shown in place of the cards when the page's filters match no standing match.
+// The accordion body is light, so this reads against it rather than the page.
+.empty-filter-message {
+    margin: 0;
+    padding: 1rem 0;
+    color: $bg-color1;
+    font-weight: 600;
+}
+
 .tournament-match__logo {
     width: 1.8em;
     height: 1.8em;

--- a/angular-app/src/app/results/standing-matches/standing-matches.component.ts
+++ b/angular-app/src/app/results/standing-matches/standing-matches.component.ts
@@ -4,9 +4,11 @@ import { Match } from '../../interfaces/match';
 import { FormBuilder } from '@angular/forms';
 import { MatchBuilder } from '../../Builders/match-builder';
 import { DynamoDb } from '../../aws-clients/dynamodb';
-import { COGNITO_UNAUTHENTICATED_CREDENTIALS, TOURNAMENT_YEAR, REGION } from '../../aws-clients/constants'
+import { COGNITO_UNAUTHENTICATED_CREDENTIALS, TOURNAMENT_YEAR, REGION, STANDING_GAME_NAME } from '../../aws-clients/constants'
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { MatchTeam } from 'src/app/interfaces/team';
+import { MatchFilters, EMPTY_MATCH_FILTERS } from 'src/app/interfaces/match-filters';
+import { applyMatchFilters } from 'src/app/utils/utils';
 
 const LOGO_PLACEHOLDER = 'assets/logo_gray.png';
 
@@ -26,12 +28,20 @@ export class StandingMatchesComponent implements OnInit, OnChanges {
   loading = true;
 
 
+  // Every standing match of each category, as loaded.
   standingMatches: Match[] = []
   standingMatchesElite: Match[] = []
+
+  // What the template renders: the selected category's matches with the parent's
+  // filters applied. Kept in sync by applyFilters().
+  visibleMatches: Match[] = []
 
   // Category to show, controlled by the shared toggle in the parent results page.
   @Input() category: 'elite' | 'aprendiz' = 'elite';
   @Input() teamLogos: {[teamId: string]: string} = {};
+  // Team/gym/date filters from the parent page. Grupo is intentionally not
+  // applied: standing matches belong to no group, so it would empty the list.
+  @Input() filters: MatchFilters = EMPTY_MATCH_FILTERS;
   @Output() matchesAvailable = new EventEmitter<boolean>();
 
   constructor(private fb: FormBuilder, 
@@ -47,8 +57,8 @@ export class StandingMatchesComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes['category']) {
-      this.emitMatchesAvailability();
+    if (changes['category'] || changes['filters']) {
+      this.applyFilters();
     }
   }
 
@@ -61,7 +71,7 @@ export class StandingMatchesComponent implements OnInit, OnChanges {
     this.allMatches = await this.matchBuilder.getListOfMatch(this.ddb, year)
     this.allMatches = this.allMatches.sort((a, b) => (a.day! + a.time!).localeCompare(b.day! + b.time!))
     this.allMatches.forEach(element => {
-      if(element.juego == 'Standing'){
+      if(element.juego == STANDING_GAME_NAME){
         if(element.category == "elite"){
           this.standingMatchesElite.push(element);
         }
@@ -71,10 +81,26 @@ export class StandingMatchesComponent implements OnInit, OnChanges {
       }
     });
     this.loading = false;
+    this.applyFilters();
+  }
+
+  // Recomputed on change rather than exposed as a getter: a getter would hand
+  // *ngFor a new array every change-detection pass and re-render the cards.
+  private applyFilters() {
+    const categoryMatches = this.category === 'elite' ? this.standingMatchesElite : this.standingMatches;
+    this.visibleMatches = applyMatchFilters(categoryMatches, this.filters, {includeGroup: false});
     this.emitMatchesAvailability();
   }
 
   get hasVisibleMatches(): boolean {
+    return this.visibleMatches.length > 0;
+  }
+
+  // Whether the category has any standing matches before filtering. The section
+  // stays hidden when it has none at all, but keeps rendering (with an empty
+  // state) when it's the filters that emptied it — otherwise the section would
+  // vanish and the filters would look broken.
+  get hasCategoryMatches(): boolean {
     return this.category === 'elite'
       ? this.standingMatchesElite.length > 0
       : this.standingMatches.length > 0;

--- a/angular-app/src/app/results/standings/standings.component.ts
+++ b/angular-app/src/app/results/standings/standings.component.ts
@@ -7,7 +7,7 @@ import { StandingBuilder } from '../../Builders/standing-builder';
 import { DynamoDb } from '../../aws-clients/dynamodb';
 import { S3 } from '../../aws-clients/s3';
 import { GroupStanding } from '../../interfaces/standing';
-import { COGNITO_UNAUTHENTICATED_CREDENTIALS, TOURNAMENT_YEAR, REGION } from '../../aws-clients/constants'
+import { COGNITO_UNAUTHENTICATED_CREDENTIALS, TOURNAMENT_YEAR, REGION, GROUP_NAMES } from '../../aws-clients/constants'
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { S3Client } from '@aws-sdk/client-s3';
 
@@ -51,7 +51,7 @@ export class StandingsComponent implements OnInit {
   loading = true;
 
   // Same group names (and order) the group-phase match list uses.
-  groups = ["Grupo 1", "Grupo 2", "Grupo 3", "Grupo 4", "Grupo A", "Grupo B", "Grupo C"]
+  groups = GROUP_NAMES
 
   // Elite first, matching the filter on the partidos page. (Listed explicitly
   // rather than via getCategories(), which returns aprendiz first.)

--- a/angular-app/src/app/utils/utils.ts
+++ b/angular-app/src/app/utils/utils.ts
@@ -1,5 +1,6 @@
 import {v4 as uuid} from 'uuid';
 import { Match } from '../interfaces/match';
+import { MatchFilters } from '../interfaces/match-filters';
 
 export function generateId(): string {
     return uuid()
@@ -17,17 +18,42 @@ export function toLocalDateTimeString(date: Date): string {
 }
 
 export function filterMatches(
-    matches: Match[], 
+    matches: Match[],
      day: string | null = null,
-     gym: string | null = null, 
+     gym: string | null = null,
      team: string | null = null,
     ): Match[] {
     let filteredMatches: Match[] = matches
     if(!matches) return filteredMatches;
     if(day) filteredMatches = filteredMatches.filter(match => match.day == day);
     if(gym) filteredMatches = filteredMatches.filter(match => match.location.id == gym);
-    if(team) filteredMatches = filteredMatches.filter(match => 
+    if(team) filteredMatches = filteredMatches.filter(match =>
       match.homeTeam.name == team || match.visitorTeam.name == team
     );
+    return filteredMatches;
+}
+
+// The calendar day a match is played on, as `YYYY-MM-DD`. Used as the value of
+// the date filter so it sorts chronologically and is stable across the
+// July/August boundary (unlike the stored day-of-month in `match.day`).
+export function matchDateKey(match: Match): string | undefined {
+    return match.datetime ? toLocalDateTimeString(match.datetime).split('T')[0] : undefined;
+}
+
+// Applies the partidos page filters to a match list. Group is only applied when
+// the caller asks for it: the standings matches aren't part of any group, so
+// filtering them by one would always empty the list.
+export function applyMatchFilters(
+    matches: Match[],
+    filters: MatchFilters,
+    { includeGroup = true }: { includeGroup?: boolean } = {}
+): Match[] {
+    let filteredMatches = matches ?? [];
+    if(includeGroup && filters.group) filteredMatches = filteredMatches.filter(match => match.juego == filters.group);
+    if(filters.teamId) filteredMatches = filteredMatches.filter(match =>
+        match.homeTeam?.id == filters.teamId || match.visitorTeam?.id == filters.teamId
+    );
+    if(filters.gymId) filteredMatches = filteredMatches.filter(match => match.location?.id == filters.gymId);
+    if(filters.day) filteredMatches = filteredMatches.filter(match => matchDateKey(match) == filters.day);
     return filteredMatches;
 }


### PR DESCRIPTION
## What

The Partidos page shows every match of the tournament at once, so finding the ones you care about means scrolling past the rest. This adds a filter bar with four selects — **Grupo**, **Equipo**, **Gimnasio**, **Fecha** — driving the Standings and Fase de Grupos sections.

The bar sits between Brackets and the sections it filters, and starts expanded so the date default is visible.

## Behavior

- **Grupo only narrows Fase de Grupos.** Standings matches belong to no group (their `juego` is `Standing`), so that section responds to the other three filters.
- **Options come from the selected category's matches only**, so a choice never yields an empty list. They're rebuilt on category switch, since teams and groups don't span categories.
- **Fecha defaults to today**, so you land on the tournament day being played. Off-tournament there's no match today and defaulting to an empty day would look broken, so it falls back to all days.
- **A section hides only when its category has no matches at all.** Filtering down to nothing shows *"No hay partidos que coincidan con los filtros seleccionados."* rather than making the section vanish.
- `Limpiar filtros` clears everything, including the date default.

## Cleanup along the way

- The group names and the standings game name were duplicated across components — now `GROUP_NAMES` / `STANDING_GAME_NAME` in `constants.ts`.
- The near-identical per-category template blocks in `groups` and `standing-matches` collapsed into one loop over the filtered list.
- Shared filtering helpers (`applyMatchFilters`, `matchDateKey`) in `utils.ts`; the pre-existing `filterMatches()` is untouched since scouting / marcador-form / match-editor still use it.

## Testing

Verified in Chrome against live DynamoDB data, both categories:

- Each filter narrows the sections it should and leaves the others alone; Grupo leaves Standings unchanged.
- Fecha preselects today (`2026-08-02` → "Domingo, 02 De Agosto"), badge shows, Fase de Grupos 45 → 7 cards all dated 02/08.
- Off-tournament fallback confirmed by pinning the clock to 2026-09-15: date resets to "Fecha", all 45 cards shown, no badge.
- Empty state reached via an impossible team+day+gym combination.
- Filter bar opens expanded, still toggles closed, stays open across a category switch.
- Four selects on one row at desktop, wrapping 2×2 at 390px.
- `ng build --configuration development` passes.

## Note

`npm test` has 15 pre-existing failures (`NG0303: Can't bind to 'formControlName'` — those specs don't import `ReactiveFormsModule`). Confirmed identical 15 failures on a stashed tree, so not a regression from this change. Happy to fix the spec setup in a follow-up.